### PR TITLE
Feature request: Added type 'custom' to error_bars on charts

### DIFF
--- a/xlsxwriter/chart.py
+++ b/xlsxwriter/chart.py
@@ -566,7 +566,9 @@ class Chart(xmlwriter.XMLwriter):
             'label_position': options.get('label_position'),
             'num_format': options.get('num_format'),
             'num_format_linked': options.get('num_format_linked'),
-            'auto': options.get('auto')
+            'auto': options.get('auto'),
+            'tick_mark_skip': options.get('tick_mark_skip'),
+            'tick_label_skip': options.get('tick_label_skip')
         }
 
         # Encode any string options passed by the user.
@@ -1536,6 +1538,12 @@ class Chart(xmlwriter.XMLwriter):
 
         # Write the c:labelOffset element.
         self._write_label_offset(100)
+
+        # Write the c:tickLblSkip element.
+        self._write_tick_label_skip(x_axis.get('tick_label_skip'))
+
+        # Write the c:tickMarkSkip element.
+        self._write_tick_mark_skip(x_axis.get('tick_mark_skip'))
 
         self._xml_end_tag('c:catAx')
 
@@ -3193,3 +3201,24 @@ class Chart(xmlwriter.XMLwriter):
             self._xml_end_tag('c:downBars')
         else:
             self._xml_empty_tag('c:downBars')
+
+    def _write_tick_label_skip(self, val):
+        # Write the <c:tickLblSkip> element.
+
+        if val is None:
+            return
+
+        attributes = [('val', val)]
+
+        self._xml_empty_tag('c:tickLblSkip', attributes)
+
+    def _write_tick_mark_skip(self, val):
+        # Write the <c:tickMarkSkip> element.
+
+        if val is None:
+            return
+
+        attributes = [('val', val)]
+
+        self._xml_empty_tag('c:tickMarkSkip', attributes)
+


### PR DESCRIPTION
Hey John -

For my project I needed Excel's 'custom' type for chart error bars. I've included a minor change to accomodate that.

Example usage is as follows:

```
        chart.add_series({
            'categories':   '=A2:A8'),
            'values':       '=C2:C8',
            'y_error_bars': {
                'type':      'custom',
                'value':     ('=B2:B8', '=D2:D8'),
                'direction': 'both'}})
```

In this case my cell composition looks like this:

|  | First Quartile | Median | Third Quartile |
| --- | :-: | :-: | :-: |
| Red | 12 | 15 | 25 |
| Blue | 10 | 45 | 60 |
| etc |  |  |  |

Please let me know what changes/tests you would like in order to be merge-ready. Thanks!
