### PR TITLE
do not catch ValueError exceptions inside method by mistake

### DIFF
--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -54,12 +54,13 @@ def convert_cell_args(method):
             # First arg is an int, default to row/col notation.
             if len(args):
                 int(args[0])
-            return method(self, *args, **kwargs)
         except ValueError:
             # First arg isn't an int, convert to A1 notation.
             new_args = list(xl_cell_to_rowcol(args[0]))
             new_args.extend(args[1:])
-            return method(self, *new_args, **kwargs)
+            args = new_args
+            
+        return method(self, *args, **kwargs)
 
     return cell_wrapper
 
@@ -76,7 +77,6 @@ def convert_range_args(method):
             # First arg is an int, default to row/col notation.
             if len(args):
                 int(args[0])
-            return method(self, *args, **kwargs)
         except ValueError:
             # First arg isn't an int, convert to A1 notation.
             if ':' in args[0]:
@@ -89,7 +89,9 @@ def convert_range_args(method):
 
             new_args = [row_1, col_1, row_2, col_2]
             new_args.extend(args[1:])
-            return method(self, *new_args, **kwargs)
+            args = new_args
+            
+        return method(self, *args, **kwargs)
 
     return cell_wrapper
 
@@ -106,7 +108,6 @@ def convert_column_args(method):
             # First arg is an int, default to row/col notation.
             if len(args):
                 int(args[0])
-            return method(self, *args, **kwargs)
         except ValueError:
             # First arg isn't an int, convert to A1 notation.
             cell_1, cell_2 = [col + '1' for col in args[0].split(':')]
@@ -114,7 +115,9 @@ def convert_column_args(method):
             _, col_2 = xl_cell_to_rowcol(cell_2)
             new_args = [col_1, col_2]
             new_args.extend(args[1:])
-            return method(self, *new_args, **kwargs)
+            args = new_args
+        
+        return method(self, *args, **kwargs)
 
     return column_wrapper
 


### PR DESCRIPTION
I had an encoding issue with data passed to worksheet.write, that made the python codecs module to raise a  UnicodeDecodeError exception.

UnicodeDecodeError is a ValueError descendant (http://docs.python.org/2/library/exceptions.html#exception-hierarchy), so the code took an unwanted path. 

My approach here is to leave only the possibly failing int(args[0]) line in the try block, moving the method call outside of the try.
