### PR TITLE
added additional ways of passing in images to Workbook._get_image_proper...

### DIFF
--- a/xlsxwriter/workbook.py
+++ b/xlsxwriter/workbook.py
@@ -862,7 +862,6 @@ class Workbook(xmlwriter.XMLwriter):
         self.drawing_count = drawing_id
 
     def _get_image_properties(self, filename):
-        '''NEEDS TESTING'''
         # Extract dimension information from the image file.
         height = 0
         width = 0


### PR DESCRIPTION
...ties

@jmcnamara
DONT MERGE ME (yet)

Hello!
I am in need of being able to pass an image as either a string or string buffer since I am working in a webapp and do not have access to files via file-path. I wrote some additional ways to open images in the Workbook._get_image_properties() method.

I need to run xlsxwriter's tests but can not figure out how to start them. Could you help me?

Thank you,
Michael Musslewhite
