### PR TITLE
Fixed: When a sheet's name contains "special" characters (e.g. whitespac...

### DIFF
--- a/xlsxwriter/chart.py
+++ b/xlsxwriter/chart.py
@@ -12,6 +12,7 @@ from .utility import xl_color
 from .utility import xl_rowcol_to_cell
 from .utility import supported_datetime
 from .utility import datetime_to_excel_datetime
+from .utility import sheet_name_to_formula_form
 
 
 class Chart(xmlwriter.XMLwriter):
@@ -694,7 +695,7 @@ class Chart(xmlwriter.XMLwriter):
         range1 = xl_rowcol_to_cell(data[1], data[2], True, True)
         range2 = xl_rowcol_to_cell(data[3], data[4], True, True)
 
-        return sheet + '!' + range1 + ':' + range2
+        return sheet_name_to_formula_form(sheet) + '!' + range1 + ':' + range2
 
     def _process_names(self, name, name_formula):
         # Switch name and name_formula parameters if required.

--- a/xlsxwriter/utility.py
+++ b/xlsxwriter/utility.py
@@ -597,3 +597,16 @@ def datetime_to_excel_datetime(dt_obj, date_1904):
         excel_time += 1
 
     return excel_time
+
+def sheet_name_to_formula_form(sheet_name):
+    # Surround sheet_name with single quotes after escaping any single quotes
+    # contained in it. This is necessary for constructing Excel ranges, e.g.:
+    # 'Sheet name'!A1:B10.
+
+    if sheet_name == '' or sheet_name.isalnum():
+    # If sheet_name has no special characters then return it unchanged. This is for
+    # simplicity, brevity, and to avoid changing existing files that were
+    # produced with versions of XlsxWriter that did not feature this
+    # function.
+        return sheet_name
+    return "'" + sheet_name.replace("'", "''") + "'"


### PR DESCRIPTION
...e or single quotes) then charts that reference that sheet's data can appear with wrong values in certain versions of Excel (notably Excel 2013). This only happens when the add_series method was called with a list as a parameter.

Fix for issue #167.
