### PR TITLE
Add 'with' statement support

### DIFF
--- a/dev/docs/source/workbook.rst
+++ b/dev/docs/source/workbook.rst
@@ -291,6 +291,19 @@ it. This is a mandatory method call::
    recommended in all XlsxWriter programs.
 
 
+It is also possible to use a `with context manager
+<https://docs.python.org/2/reference/compound_stmts.html#with>`_ to control the
+lifetime of the workbook like this::
+
+    with xlsxwriter.Workbook('test.xlsx') as workbook:
+        worksheet = workbook.add_worksheet()
+        ...
+
+The workbook will automatically close when exiting the scope of the ``with``
+statement. 
+
+
+
 workbook.set_properties()
 -------------------------
 

--- a/xlsxwriter/test/comparison/test_simple01.py
+++ b/xlsxwriter/test/comparison/test_simple01.py
@@ -67,6 +67,17 @@ class TestCompareXLSXFiles(ExcelComparisonTest):
 
         self.assertExcelEqual()
 
+    def test_create_file_with_statement(self):
+        """Test the creation of a simple workbook using `with` statement."""
+
+        with Workbook(self.got_filename) as workbook:
+            worksheet = workbook.add_worksheet()
+
+            worksheet.write(0, 0, 'Hello')
+            worksheet.write(1, 0, 123)
+
+        self.assertExcelEqual()
+
     def test_create_file_write_A1(self):
         """Test the creation of a simple workbook using write() with A1."""
 

--- a/xlsxwriter/workbook.py
+++ b/xlsxwriter/workbook.py
@@ -147,6 +147,14 @@ class Workbook(xmlwriter.XMLwriter):
             raise Exception("Exception caught in workbook destructor. "
                             "Explicit close() may be required for workbook.")
 
+    def __enter__(self):
+        """Return self object to use with "with" statement."""
+        return self
+
+    def __exit__(self, type, value, traceback):
+        """Close workbook when exiting "with" statement."""
+        self.close()
+
     def add_worksheet(self, name=None):
         """
         Add a new worksheet to the Excel workbook.


### PR DESCRIPTION
This allows you to use 'with' statement for your workbook like this:

    with xlsxwriter.Workbook('test.xlsx') as workbook:
        worksheet = workbook.add_worksheet()
        ...

The workbook will automatically close when exiting "with" statement scope.