### PR TITLE
Fixes unicode text handling in warnings fixes #300

### DIFF
--- a/xlsxwriter/compatibility.py
+++ b/xlsxwriter/compatibility.py
@@ -42,3 +42,11 @@ if sys.version_info < (2, 6, 0):
     from StringIO import StringIO as BytesIO
 else:
     from io import BytesIO as BytesIO
+
+
+def force_unicode(string):
+    """Return string as a native string"""
+    if sys.version_info[0] == 2:
+        if isinstance(string, unicode):
+            return string.encode('utf-8')
+    return string

--- a/xlsxwriter/workbook.py
+++ b/xlsxwriter/workbook.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from zipfile import ZipFile, ZIP_DEFLATED
 from struct import unpack
 
-from .compatibility import str_types
+from .compatibility import str_types, force_unicode
 
 # Package imports.
 from . import xmlwriter
@@ -273,7 +273,8 @@ class Workbook(xmlwriter.XMLwriter):
 
         """
         if not is_stream and not os.path.exists(vba_project):
-            warn("VBA project binary file '%s' not found." % vba_project)
+            warn("VBA project binary file '%s' not found."
+                 % force_unicode(vba_project))
             return -1
 
         self.vba_project = vba_project
@@ -364,7 +365,8 @@ class Workbook(xmlwriter.XMLwriter):
 
             # Warn if the sheet index wasn't found.
             if sheet_index is None:
-                warn("Unknown sheet name '%s' in defined_name()" % sheetname)
+                warn("Unknown sheet name '%s' in defined_name()"
+                     % force_unicode(sheetname))
                 return -1
         else:
             # Use -1 to indicate global names.
@@ -1307,7 +1309,8 @@ class Workbook(xmlwriter.XMLwriter):
                 # in a chart series formula.
                 if sheetname not in worksheets:
                     warn("Unknown worksheet reference '%s' in range "
-                         "'%s' passed to add_series()" % (sheetname, c_range))
+                         "'%s' passed to add_series()"
+                         % (force_unicode(sheetname), force_unicode(c_range)))
                     chart.formula_data[r_id] = []
                     seen_ranges[c_range] = []
                     continue

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -17,6 +17,7 @@ from warnings import warn
 from .compatibility import StringIO
 from .compatibility import defaultdict
 from .compatibility import namedtuple
+from .compatibility import force_unicode
 from .compatibility import num_types, str_types
 
 # Package imports.
@@ -842,7 +843,7 @@ class Worksheet(xmlwriter.XMLwriter):
         # Excel limits escaped URL to 255 characters.
         if len(url) > 255:
             warn("Ignoring URL '%s' > 255 characters since it exceeds "
-                 "Excel's limit for URLS" % url)
+                 "Excel's limit for URLS" % force_unicode(url))
             return -3
 
         # Check the limit of URLS per worksheet.
@@ -850,7 +851,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
         if self.hlink_count > 65530:
             warn("Ignoring URL '%s' since it exceeds Excel's limit of "
-                 "65,530 URLS per worksheet." % url)
+                 "65,530 URLS per worksheet." % force_unicode(url))
             return -5
 
         # Write previous row if in in-line string optimization mode.
@@ -1055,7 +1056,7 @@ class Worksheet(xmlwriter.XMLwriter):
         image_data = options.get('image_data', None)
 
         if not image_data and not os.path.exists(filename):
-            warn("Image file '%s' not found." % filename)
+            warn("Image file '%s' not found." % force_unicode(filename))
             return -1
 
         self.images.append([row, col, filename, x_offset, y_offset,
@@ -1791,27 +1792,27 @@ class Worksheet(xmlwriter.XMLwriter):
         # Check that the input title dosen't exceed the maximum length.
         if options.get('input_title') and len(options['input_title']) > 32:
             warn("Length of input title '%s' exceeds Excel's limit of 32"
-                 % options['input_title'])
+                 % force_unicode(options['input_title']))
             return -2
 
         # Check that the error title doesn't exceed the maximum length.
         if options.get('error_title') and len(options['error_title']) > 32:
             warn("Length of error title '%s' exceeds Excel's limit of 32"
-                 % options['error_title'])
+                 % force_unicode(options['error_title']))
             return -2
 
         # Check that the input message dosen't exceed the maximum length.
         if (options.get('input_message')
                 and len(options['input_message']) > 255):
             warn("Length of input message '%s' exceeds Excel's limit of 255"
-                 % options['input_message'])
+                 % force_unicode(options['input_message']))
             return -2
 
         # Check that the error message doesn't exceed the maximum length.
         if (options.get('error_message')
                 and len(options['error_message']) > 255):
             warn("Length of error message '%s' exceeds Excel's limit of 255"
-                 % options['error_message'])
+                 % force_unicode(options['error_message']))
             return -2
 
         # Check that the input list doesn't exceed the maximum length.
@@ -1819,7 +1820,8 @@ class Worksheet(xmlwriter.XMLwriter):
             formula = self._csv_join(*options['value'])
             if len(formula) > 255:
                 warn("Length of list items '%s' exceeds Excel's limit of "
-                     "255, use a formula range instead" % formula)
+                     "255, use a formula range instead"
+                     % force_unicode(formula))
                 return -2
 
         # Set some defaults if they haven't been defined by the user.


### PR DESCRIPTION
Adds `force_unicode` function to force unicode strings into native strings.
This converts Python 2.x unicode strings into bytestrings to fix `UnicodeEncodeErrors` produced when trying to emit warnings using non-ascii characters.