### PR TITLE
Fixes missing import in shape module

### DIFF
--- a/xlsxwriter/shape.py
+++ b/xlsxwriter/shape.py
@@ -5,6 +5,7 @@
 # Copyright 2013-2015, John McNamara, jmcnamara@cpan.org
 #
 import copy
+from warnings import warn
 
 
 class Shape(object):


### PR DESCRIPTION
There is a missing import in the shape module, where the warn function is used:

```
# shape.py
(...)
            if align_type in align_types:
                align['vertical'] = align_types[align_type]
            else:
                warn("Unknown alignment type '%s'" % align_type)
                return {'defined': False}
```

`warn` is undefined, so `from warnings import warn` its needed.