### PR TITLE
Feature to write the Hyperlink base property

### DIFF
--- a/examples/doc_properties.py
+++ b/examples/doc_properties.py
@@ -19,6 +19,7 @@ workbook.set_properties({
     'keywords': 'Sample, Example, Properties',
     'comments': 'Created with Python and XlsxWriter',
     'status':   'Quo',
+    'hyperlink_base': 'C:\\',
 })
 
 worksheet.set_column('A:A', 70)

--- a/xlsxwriter/app.py
+++ b/xlsxwriter/app.py
@@ -73,6 +73,7 @@ class App(xmlwriter.XMLwriter):
         self._write_titles_of_parts()
         self._write_manager()
         self._write_company()
+        self._write_hyperlink_base()
         self._write_links_up_to_date()
         self._write_shared_doc()
         self._write_hyperlinks_changed()
@@ -168,6 +169,13 @@ class App(xmlwriter.XMLwriter):
             return
 
         self._xml_data_element('Manager', self.properties['manager'])
+
+    def _write_hyperlink_base(self):
+        # Write the <HyperlinkBase> element.
+        if 'hyperlink_base' not in self.properties:
+            return
+
+        self._xml_data_element('HyperlinkBase', self.properties['hyperlink_base'])
 
     def _write_links_up_to_date(self):
         # Write the <LinksUpToDate> element.


### PR DESCRIPTION
Adds the ability to write the Hyperlink base property which is visible when you use the Office Button -> Prepare -> Properties option in Excel:
https://xlsxwriter.readthedocs.org/en/latest/_images/doc_properties.png

This is an extended property like Company and Manager, which gets written in app.py.

The qualified name for the Hyperlink base property is HyperlinkBase as seen here:
https://msdn.microsoft.com/en-AU/library/documentformat.openxml.extendedproperties.hyperlinkbase(v=office.14).aspx