### PR TITLE
Prevent write_url crashes due to invalid URLs

### DIFF
--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -816,7 +816,8 @@ class Worksheet(xmlwriter.XMLwriter):
 
             # Split url into the link and optional anchor/location.
             if '#' in url:
-                url, url_str = url.split('#')
+                # Python 2 does not support the maxsplit keyword argument.
+                url, url_str = url.split('#', 1)
             else:
                 url_str = None
 


### PR DESCRIPTION
RFC 3986 forbids URL fragments from containing the `#` character but several websites are less well behaved.

In either case, invalid URLs like `http://google.com#foo#bar` should be the callers problem and should not cause a hard crash in xlsxwriter.