### PR TITLE
Support paths with ~

### DIFF
--- a/xlsxwriter/test/workbook/test_expanduser.py
+++ b/xlsxwriter/test/workbook/test_expanduser.py
@@ -1,0 +1,47 @@
+###############################################################################
+#
+# Tests for XlsxWriter.
+#
+# Copyright (c), 2013-2015, John McNamara, jmcnamara@cpan.org
+#
+
+import os
+from zipfile import ZipFile
+import unittest
+from ... import workbook as wb
+from ...workbook import Workbook
+
+
+class TestExpandUser(unittest.TestCase):
+    """
+    Test storing workbook in a home directory.
+
+    """
+
+    def setUp(self):
+        wb.ZipFile = ZipFileMock
+
+    def tearDown(self):
+        wb.ZipFile = ZipFile
+
+    def test_expanduser(self):
+        home_path = '~/tmp/xlsxwriter_test/book.xlsx'
+        expanded_path = os.path.expanduser(home_path)
+        self.assertNotEqual(home_path, expanded_path)
+        workbook = Workbook(home_path)
+        workbook.close()
+        self.assertEqual(ZipFileMock.calls, [expanded_path])
+
+
+class ZipFileMock(object):
+
+    calls = []
+
+    def __init__(self, file, *args, **kwargs):
+        ZipFileMock.calls.append(file)
+
+    def write(self, *args, **kwargs):
+        pass
+
+    def close(self):
+        pass

--- a/xlsxwriter/workbook.py
+++ b/xlsxwriter/workbook.py
@@ -522,7 +522,10 @@ class Workbook(xmlwriter.XMLwriter):
         # Free up the Packager object.
         packager = None
 
-        xlsx_file = ZipFile(self.filename, "w", compression=ZIP_DEFLATED,
+        zip_filename = self.filename
+        if isinstance(zip_filename, str):
+            zip_filename = os.path.expanduser(zip_filename)
+        xlsx_file = ZipFile(zip_filename, "w", compression=ZIP_DEFLATED,
                             allowZip64=self.allow_zip64)
 
         # Add XML sub-files to the Zip file with their Excel filename.


### PR DESCRIPTION
Fixes #320 

Tested with `tox -e py27,py34,py35`

Coding style checked with `pep8` and `flake8`

Note: In unit test, I used custom class for mock. XlsxWriter seems to support ancient Python versions, so I implemented it in the most simple, stupid and portable way.