### PR TITLE
Urls format overriding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ class PyTest(Command):
 
 setup(
     name='XlsxWriter',
-    version='0.8.4',
+    version='0.8.5',
     author='John McNamara',
     author_email='jmcnamara@cpan.org',
     url='https://github.com/jmcnamara/XlsxWriter',

--- a/xlsxwriter/workbook.py
+++ b/xlsxwriter/workbook.py
@@ -71,6 +71,8 @@ class Workbook(xmlwriter.XMLwriter):
         self.excel2003_style = options.get('excel2003_style', False)
         self.default_format_properties = \
             options.get('default_format_properties', {})
+        self.override_urls_format = options.get('override_urls_format', True)
+
 
         self.worksheet_meta = WorksheetMeta()
         self.selected = 0
@@ -565,6 +567,7 @@ class Workbook(xmlwriter.XMLwriter):
             'default_date_format': self.default_date_format,
             'default_url_format': self.default_url_format,
             'excel2003_style': self.excel2003_style,
+            'override_urls_format': self.override_urls_format,
         }
 
         if is_chartsheet:

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -330,6 +330,7 @@ class Worksheet(xmlwriter.XMLwriter):
         self.strings_to_urls = True
         self.nan_inf_to_errors = False
         self.strings_to_formulas = True
+        self.override_urls_format = True
 
         self.default_date_format = None
         self.default_url_format = None
@@ -849,7 +850,7 @@ class Worksheet(xmlwriter.XMLwriter):
             self._write_single_row(row)
 
         # Add the default URL format.
-        if cell_format is None:
+        if cell_format is None or not self.override_urls_format:
             cell_format = self.default_url_format
 
         # Write the hyperlink string.
@@ -3367,6 +3368,7 @@ class Worksheet(xmlwriter.XMLwriter):
         self.default_date_format = init_data['default_date_format']
         self.default_url_format = init_data['default_url_format']
         self.excel2003_style = init_data['excel2003_style']
+        self.override_urls_format = init_data['override_urls_format']
 
         if self.excel2003_style:
             self.original_row_height = 12.75


### PR DESCRIPTION
Here was the question: 
http://stackoverflow.com/questions/35745451/python-xlsxwriter-text-wrapping-and-links-styling
I want to add the support of overriding the urls styles, if the user added base formatting for text and he tries to write data with the `write_row`
```python
import xlsxwriter

workbook = xlsxwriter.Workbook('my_export.xlsx')
worksheet = workbook.add_worksheet(name='export_object1')

text_format = workbook.add_format({'text_wrap': True})
worksheet.write_row('A1', [
    u'Its\na bum\nwrap',
    'external:resignation_letter.docx',
], text_format)
```
now It can looks like:
`xlsxwriter.Workbook(fname, {'override_urls_format': False})`
So the text format will be overridden, but link's format - not.
by default overriding of urls formatting will be enabled, as earlier