### PR TITLE
Do not crash on too long sheet name

### DIFF
--- a/dev/docs/source/workbook.rst
+++ b/dev/docs/source/workbook.rst
@@ -169,7 +169,7 @@ Excel convention will be followed, i.e. Sheet1, Sheet2, etc.::
 
 The worksheet name must be a valid Excel worksheet name, i.e. it cannot contain
 any of the characters ``' [ ] : * ? / \
-'`` and it must be less than 32 characters.
+'`` and it is cropped at 31 characters.
 
 In addition, you cannot use the same, case insensitive, ``name`` for more
 than one worksheet.

--- a/xlsxwriter/test/workbook/test_check_sheetname.py
+++ b/xlsxwriter/test/workbook/test_check_sheetname.py
@@ -33,19 +33,17 @@ class TestCheckSheetname(unittest.TestCase):
         exp = 'Sheet3'
         self.assertEqual(got, exp)
 
-    def test_check_sheetname_with_exception1(self):
-        """Test the _check_sheetname() method with exception"""
-
         name = 'name_that_is_longer_than_thirty_one_characters'
-        self.assertRaises(Exception, self.workbook._check_sheetname, name)
+        got = self.workbook._check_sheetname(name)
+        self.assertEqual(len(got), 31)
 
-    def test_check_sheetname_with_exception2(self):
+    def test_check_sheetname_with_exception1(self):
         """Test the _check_sheetname() method with exception"""
 
         name = 'name_with_special_character_?'
         self.assertRaises(Exception, self.workbook._check_sheetname, name)
 
-    def test_check_sheetname_with_exception3(self):
+    def test_check_sheetname_with_exception2(self):
         """Test the _check_sheetname() method with exception"""
 
         name1 = 'Duplicate_name'

--- a/xlsxwriter/workbook.py
+++ b/xlsxwriter/workbook.py
@@ -680,10 +680,8 @@ class Workbook(xmlwriter.XMLwriter):
             else:
                 sheetname = self.sheet_name + str(self.sheetname_count)
 
-        # Check that sheet sheetname is <= 31. Excel limit.
-        if len(sheetname) > 31:
-            raise Exception("Excel worksheet name '%s' must be <= 31 chars." %
-                            sheetname)
+        # sheet name must be <= 31. Excel limit.
+        sheetname = sheetname[:31]
 
         # Check that sheetname doesn't contain any invalid characters
         if invalid_char.search(sheetname):


### PR DESCRIPTION
The name of a sheet is maximum 31 char long due to an Excel limit.
While the other constrains (invalid character and duplicated) are not possible
to be fixed without user maniupulations, fixing the sheet name size is easy and
does not force the size limitation to be handled by the library user.

Remove the raise Exception and keep only the first 31 characters.

See #364 for details

Should I change the version number too?