### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ The [Changes](https://github.com/jmcnamara/XlsxWriter/blob/master/Changes) file 
 
 ### Read the documentation
 
-Read or search the [XlsxWriter documentation](https://xlsxwriter.readthedocs.org/en/latest/index.html) to see if the issue you are encountering is already explained.
+Read or search the [XlsxWriter documentation](https://xlsxwriter.readthedocs.io/) to see if the issue you are encountering is already explained.
 
 ### Look at the example programs
 
@@ -118,7 +118,7 @@ As a minimum, tests should be run using Python 2.7 and Python 3.5.
     # or
     py.test
 
-I use [pythonbrew](https://github.com/utahta/pythonbrew) and [Tox](http://tox.readthedocs.org/en/latest/) to test with a variety of Python versions. See the Makefile for example test targets. A `tox.ini` file is already configured.
+I use [pythonbrew](https://github.com/utahta/pythonbrew) and [Tox](https://tox.readthedocs.io/en/latest/) to test with a variety of Python versions. See the Makefile for example test targets. A `tox.ini` file is already configured.
 
 When you push your changes they will also be tested using [Travis CI](https://travis-ci.org/jmcnamara/XlsxWriter/) as explained above.
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -54,7 +54,7 @@ As a minimum, tests should be run using Python 2.7 and Python 3.5.
     # or
     py.test
 
-I use [pythonbrew](https://github.com/utahta/pythonbrew) and [Tox](http://tox.readthedocs.org/en/latest/) to test with a variety of Python versions. See the Makefile for example test targets. A `tox.ini` file is already configured.
+I use [pythonbrew](https://github.com/utahta/pythonbrew) and [Tox](https://tox.readthedocs.io/en/latest/) to test with a variety of Python versions. See the Makefile for example test targets. A `tox.ini` file is already configured.
 
 When you push your changes they will also be tested using [Travis CI](https://travis-ci.org/jmcnamara/XlsxWriter/) as explained above.
 

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Here is a simple example:
 
 .. image:: https://raw.github.com/jmcnamara/XlsxWriter/master/dev/docs/source/_images/demo.png
 
-See the full documentation at: http://xlsxwriter.readthedocs.org
+See the full documentation at: https://xlsxwriter.readthedocs.io
 
-Release notes: http://xlsxwriter.readthedocs.org/changes.html
+Release notes: https://xlsxwriter.readthedocs.io/changes.html
 

--- a/dev/docs/source/getting_started.rst
+++ b/dev/docs/source/getting_started.rst
@@ -104,7 +104,7 @@ Documentation
 -------------
 
 The latest version of this document is hosted on
-`Read The Docs <http://xlsxwriter.readthedocs.org>`_. It is also
+`Read The Docs <https://xlsxwriter.readthedocs.io>`_. It is also
 available as a
 `PDF <https://github.com/jmcnamara/XlsxWriter/raw/master/docs/XlsxWriter.pdf>`_.
 

--- a/dev/docs/source/working_with_pandas.rst
+++ b/dev/docs/source/working_with_pandas.rst
@@ -252,7 +252,7 @@ Here are some additional resources in relation to Pandas, Excel and XlsxWriter.
 
 * A more detailed tutorial on `Using Pandas and XlsxWriter to create Excel
   charts
-  <http://pandas-xlsxwriter-charts.readthedocs.org/en/latest/index.html>`_.
+  <https://pandas-xlsxwriter-charts.readthedocs.io/>`_.
 
 * The series of articles on the "Practical Business Python" website about
   `Using Pandas and Excel <http://pbpython.com/tag/excel.html>`_.

--- a/docs/readme.html
+++ b/docs/readme.html
@@ -126,7 +126,7 @@ XlsxWriter.</p>
 <div class="section" id="documentation">
 <h1>Documentation</h1>
 <p>The full version of XlsxWriter documentation is hosted on
-<a class="reference external" href="http://xlsxwriter.readthedocs.org">Read The Docs</a>. It is
+<a class="reference external" href="https://xlsxwriter.readthedocs.io">Read The Docs</a>. It is
 also available as a
 <a class="reference external" href="https://github.com/jmcnamara/XlsxWriter/raw/master/docs/XlsxWriter.pdf">PDF</a>.</p>
 </div>

--- a/examples/vba_extract.py
+++ b/examples/vba_extract.py
@@ -22,7 +22,7 @@ else:
     print("\nUtility to extract a vbaProject.bin binary from an Excel 2007+ "
           "xlsm macro file for insertion into an XlsxWriter file."
           "\n"
-          "See: http://xlsxwriter.readthedocs.org/working_with_macros.html\n"
+          "See: https://xlsxwriter.readthedocs.io/working_with_macros.html\n"
           "\n"
           "Usage: vba_extract file.xlsm\n")
     exit()


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.