### PR TITLE
Fix minor syntax issue in chart documentation

### DIFF
--- a/dev/docs/source/chart.rst
+++ b/dev/docs/source/chart.rst
@@ -11,7 +11,7 @@ Scatter, Stock and Radar.
 A chart object is created via the Workbook :func:`add_chart()` method where the
 chart type is specified::
 
-    chart = workbook.add_chart({type, 'column'})
+    chart = workbook.add_chart({'type': 'column'})
 
 It is then inserted into a worksheet as an embedded chart using the
 :func:`insert_chart` Worksheet method::


### PR DESCRIPTION
This pull request fixes http://xlsxwriter.readthedocs.io/chart.html page of the XlsxWriter documentation by renaming
```python
chart = workbook.add_chart({type, 'column'})
```
to
```python
chart = workbook.add_chart({'type': 'column'})
```

fixes #393