### PR TITLE
issue #401. Ability to customize Chartsheet and Worksheet

### DIFF
--- a/xlsxwriter/test/workbook/test_custom_sheet.py
+++ b/xlsxwriter/test/workbook/test_custom_sheet.py
@@ -1,0 +1,71 @@
+###############################################################################
+#
+# Tests for XlsxWriter.
+#
+# Copyright (c), 2013-2016, John McNamara, jmcnamara@cpan.org
+#
+
+import unittest
+
+from xlsxwriter.chartsheet import Chartsheet
+from xlsxwriter.worksheet import Worksheet
+from ...workbook import Workbook
+
+
+class MyWorksheet(Worksheet):
+    pass
+
+
+class MyChartsheet(Chartsheet):
+    pass
+
+
+class MyWorkbook(Workbook):
+    chartsheet_class = MyChartsheet
+    worksheet_class = MyWorksheet
+
+
+class TestCustomSheet(unittest.TestCase):
+    """
+    Test the Workbook _check_sheetname() method.
+
+    """
+
+    def setUp(self):
+        self.workbook = Workbook()
+
+    def test_check_chartsheet(self):
+        """Test the _check_sheetname() method"""
+        sheet = self.workbook.add_chartsheet()
+        assert isinstance(sheet, Chartsheet)
+
+        sheet = self.workbook.add_chartsheet(chartsheet_class=MyChartsheet)
+        assert isinstance(sheet, MyChartsheet)
+
+    def test_check_worksheet(self):
+        """Test the _check_sheetname() method"""
+        sheet = self.workbook.add_worksheet()
+        assert isinstance(sheet, Worksheet)
+
+        sheet = self.workbook.add_worksheet(worksheet_class=MyWorksheet)
+        assert isinstance(sheet, MyWorksheet)
+
+
+class TestCustomWorkBook(unittest.TestCase):
+    """
+    Test the Workbook _check_sheetname() method.
+
+    """
+
+    def setUp(self):
+        self.workbook = MyWorkbook()
+
+    def test_check_chartsheet(self):
+        """Test the _check_sheetname() method"""
+        sheet = self.workbook.add_chartsheet()
+        assert isinstance(sheet, MyChartsheet)
+
+    def test_check_worksheet(self):
+        """Test the _check_sheetname() method"""
+        sheet = self.workbook.add_worksheet()
+        assert isinstance(sheet, MyWorksheet)

--- a/xlsxwriter/workbook.py
+++ b/xlsxwriter/workbook.py
@@ -10,6 +10,7 @@ import sys
 import re
 import os
 import operator
+import warnings
 from warnings import warn
 from datetime import datetime
 from zipfile import ZipFile, ZIP_DEFLATED
@@ -48,6 +49,8 @@ class Workbook(xmlwriter.XMLwriter):
     # Public API.
     #
     ###########################################################################
+    chartsheet_class = Chartsheet
+    worksheet_class = Worksheet
 
     def __init__(self, filename=None, options={}):
         """
@@ -157,7 +160,7 @@ class Workbook(xmlwriter.XMLwriter):
         """Close workbook when exiting "with" statement."""
         self.close()
 
-    def add_worksheet(self, name=None):
+    def add_worksheet(self, name=None, worksheet_class=None):
         """
         Add a new worksheet to the Excel workbook.
 
@@ -168,9 +171,11 @@ class Workbook(xmlwriter.XMLwriter):
             Reference to a worksheet object.
 
         """
-        return self._add_sheet(name, is_chartsheet=False)
+        if worksheet_class is None:
+            worksheet_class = self.worksheet_class
+        return self._add_sheet(name, is_chartsheet=False, worksheet_class=worksheet_class)
 
-    def add_chartsheet(self, name=None):
+    def add_chartsheet(self, name=None, chartsheet_class=None):
         """
         Add a new chartsheet to the Excel workbook.
 
@@ -181,7 +186,9 @@ class Workbook(xmlwriter.XMLwriter):
             Reference to a chartsheet object.
 
         """
-        return self._add_sheet(name, is_chartsheet=True)
+        if chartsheet_class is None:
+            chartsheet_class = self.chartsheet_class
+        return self._add_sheet(name, is_chartsheet=True, worksheet_class=chartsheet_class)
 
     def add_format(self, properties={}):
         """
@@ -627,11 +634,25 @@ class Workbook(xmlwriter.XMLwriter):
 
         xlsx_file.close()
 
-    def _add_sheet(self, name, is_chartsheet):
+    def _add_sheet(self, name, is_chartsheet=None, worksheet_class=None):
         # Utility for shared code in add_worksheet() and add_chartsheet().
+        if is_chartsheet is not None:
+            warnings.warn(
+                "'is_chartsheet' has been deprecated and "
+                "will be removed in the next versions. Use proper 'worksheet_class' to get same result",
+                          PendingDeprecationWarning)
+        if is_chartsheet is None and worksheet_class is None:
+            raise ValueError("You must provide 'is_chartsheet' or 'worksheet_class'")
+        if worksheet_class:
+            worksheet = worksheet_class()
+        else:
+            if is_chartsheet:
+                worksheet = self.chartsheet_class()
+            else:
+                worksheet = self.worksheet_class()
 
         sheet_index = len(self.worksheets_objs)
-        name = self._check_sheetname(name, is_chartsheet)
+        name = self._check_sheetname(name, isinstance(worksheet, Chartsheet))
 
         # Initialization data to pass to the worksheet.
         init_data = {
@@ -651,11 +672,6 @@ class Workbook(xmlwriter.XMLwriter):
             'excel2003_style': self.excel2003_style,
             'remove_timezone': self.remove_timezone,
         }
-
-        if is_chartsheet:
-            worksheet = Chartsheet()
-        else:
-            worksheet = Worksheet()
 
         worksheet._initialize(init_data)
 


### PR DESCRIPTION
on `Workbook`
add 2 class attributes  `chartsheet_class` and `worksheet_class`.

Further improvements can be to remove `is_chartsheet` argument in `_add_sheet` (deprecate for a while and remove later.
Not sure is a type check in `add_chartsheet` to guarantee that no other types of sheets are passed in klass (es. `add_chartsheet(klass=Worksheet)`, looks like a bit "obsessive" but better to ask.