### PR TITLE
Prevent from passing empty string as a name of worksheet.

### DIFF
--- a/xlsxwriter/test/workbook/test_check_sheetname.py
+++ b/xlsxwriter/test/workbook/test_check_sheetname.py
@@ -54,5 +54,11 @@ class TestCheckSheetname(unittest.TestCase):
         self.workbook.add_worksheet(name1)
         self.assertRaises(Exception, self.workbook.add_worksheet, name2)
 
+    def test_check_sheetname_empty_exception(self):
+        """Test the _check_sheetname() method with empty name"""
+
+        name = ''
+        self.assertRaises(Exception, self.workbook._check_sheetname, name)
+
     def tearDown(self):
         self.workbook.fileclosed = 1

--- a/xlsxwriter/workbook.py
+++ b/xlsxwriter/workbook.py
@@ -683,6 +683,10 @@ class Workbook(xmlwriter.XMLwriter):
             else:
                 sheetname = self.sheet_name + str(self.sheetname_count)
 
+        # Check if sheetname is empty.
+        if sheetname == '':
+            raise Exception("Excel worksheet name cannot be empty")    
+
         # Check that sheet sheetname is <= 31. Excel limit.
         if len(sheetname) > 31:
             raise Exception("Excel worksheet name '%s' must be <= 31 chars." %


### PR DESCRIPTION
See #407 
