### PR TITLE
fixed close() method of workbook

### DIFF
--- a/xlsxwriter/workbook.py
+++ b/xlsxwriter/workbook.py
@@ -307,8 +307,8 @@ class Workbook(xmlwriter.XMLwriter):
 
         """
         if not self.fileclosed:
-            self.fileclosed = 1
             self._store_workbook()
+            self.fileclosed = 1
 
     def set_size(self, width, height):
         """


### PR DESCRIPTION
[issue tracker](https://github.com/jmcnamara/XlsxWriter/issues/469) and [issue tracker](https://github.com/jmcnamara/XlsxWriter/issues/471)

close() method should mark that file has been saved (and closed) after successfully saving it.
If _store_workbook() throws an exception (for instance in case when file is opened by another application, e.g. excel), file should not be marked as saved (closed), since next save() call will not try to save it.