### PR TITLE
Modification to enable producing consistent binary output

### DIFF
--- a/xlsxwriter/workbook.py
+++ b/xlsxwriter/workbook.py
@@ -624,17 +624,11 @@ class Workbook(xmlwriter.XMLwriter):
         xlsx_file = ZipFile(self.filename, "w", compression=ZIP_DEFLATED,
                             allowZip64=self.allow_zip64)
 
-        timestamp_for_tempfiles = self.doc_properties.get('created', None)
-
         # Add XML sub-files to the Zip file with their Excel filename.
         for os_filename, xml_filename, is_binary in xml_files:
             if self.in_memory:
 
-                if timestamp_for_tempfiles:
-                    zipinfo = ZipInfo(xml_filename, timestamp_for_tempfiles.timetuple())
-                else:
-                    zipinfo = ZipInfo(xml_filename)
-
+                zipinfo = ZipInfo(xml_filename, (1980, 1, 1, 0, 0, 0))
                 if is_binary:
                     xlsx_file.writestr(zipinfo, os_filename.getvalue())
                 else:
@@ -643,9 +637,8 @@ class Workbook(xmlwriter.XMLwriter):
             else:
                 # The files are tempfiles.
 
-                if timestamp_for_tempfiles:
-                    timestamp = time.mktime(timestamp_for_tempfiles.timetuple())
-                    os.utime(os_filename, (timestamp, timestamp))
+                timestamp = time.mktime((1980, 1, 1, 0, 0, 0, 0, 0, 0))
+                os.utime(os_filename, (timestamp, timestamp))
 
                 xlsx_file.write(os_filename, xml_filename)
                 os.remove(os_filename)


### PR DESCRIPTION
Enabling consistent binary output by taking creation time from the metadata (if set) and:

1. using ZipInfo structure with that date for in-memory zipping

1. setting temporary files' modification time to that date with file-based zipping.

For more info see issue https://github.com/jmcnamara/XlsxWriter/issues/494.

Usage:

```python
from datetime import datetime
import xlsxwriter
import zipfile

options, properties = {}, {}
options = {'in_memory': True}
properties = {'created':  datetime(2017, 12, 31, 23, 59, 58)}
# properties = {'created':  datetime.now().date()}

path = 'demo.xlsx'

with xlsxwriter.Workbook(path, options) as workbook:
    if properties:
        workbook.set_properties(properties)
    worksheet = workbook.add_worksheet()
    worksheet.write('A1', 'abc')

with zipfile.ZipFile(path, 'r') as archive:
    for info in sorted(archive.infolist(), key=lambda i: i.filename):
        print("{} {}".format(datetime(*info.date_time).strftime("%Y-%m-%d %H:%M:%S"), info.filename))
```
