### PR TITLE
Minor: Add legend option 'top_right' and 'overlay_top_right' for chart legends

### DIFF
--- a/dev/docs/source/chart.rst
+++ b/dev/docs/source/chart.rst
@@ -770,11 +770,13 @@ The options that can be set are::
   The default legend position is ``right``. The available positions are::
 
     top
+    top_right
     bottom
     left
     right
     overlay_left
     overlay_right
+    overlay_top_right
     none
 
 * ``layout``: Set the ``(x, y)`` position of the legend in chart relative

--- a/xlsxwriter/chart.py
+++ b/xlsxwriter/chart.py
@@ -2582,6 +2582,7 @@ class Chart(xmlwriter.XMLwriter):
             'right': 'r',
             'left': 'l',
             'top': 't',
+            'top_right': 'tr',
             'bottom': 'b',
         }
 


### PR DESCRIPTION
Also updated docs to reflect new option.

Legend chart option 'tr' reverse engineered from sample XLSX file with that option for the legend set, results in 'tr' value for chart legend:

```
<c:legend>
    <c:legendPos val="tr" />
    <c:layout/>
    <c:overlay val="1" />
</c:legend>
```

Addresses feature request #537.

Testing: no tests for charts found yet? Since this is minor at best, skipping writing new test suite for chart code.