### PR TITLE
Fix compression for in-memory workbooks

### DIFF
--- a/xlsxwriter/workbook.py
+++ b/xlsxwriter/workbook.py
@@ -659,6 +659,10 @@ class Workbook(xmlwriter.XMLwriter):
             if self.in_memory:
 
                 zipinfo = ZipInfo(xml_filename, (1980, 1, 1, 0, 0, 0))
+                # Copy compression type from ZipFile because ZipInfo defaults
+                # to ZIP_STORED
+                zipinfo.compress_type = xlsx_file.compression
+
                 if is_binary:
                     xlsx_file.writestr(zipinfo, os_filename.getvalue())
                 else:


### PR DESCRIPTION
This small change fixes the compression problem with in-memory workbooks.

I could've added compression type to the `writestr()` calls, but I found it cleaner to set it in a single place.

After applying the fix and running the sample code the resulting file is now correctly compressed:
```
$ zipinfo sample.xlsx
Archive:  sample.xlsx
Zip file size: 4950 bytes, number of entries: 9
?rw-------  2.0 unx      516 b- defN 80-Jan-01 00:00 xl/worksheets/sheet1.xml
?rw-------  2.0 unx      550 b- defN 80-Jan-01 00:00 xl/workbook.xml
?rw-------  2.0 unx      784 b- defN 80-Jan-01 00:00 docProps/app.xml
?rw-------  2.0 unx      592 b- defN 80-Jan-01 00:00 docProps/core.xml
?rw-------  2.0 unx     1031 b- defN 80-Jan-01 00:00 [Content_Types].xml
?rw-------  2.0 unx      867 b- defN 80-Jan-01 00:00 xl/styles.xml
?rw-------  2.0 unx     6994 b- defN 80-Jan-01 00:00 xl/theme/theme1.xml
?rw-------  2.0 unx      587 b- defN 80-Jan-01 00:00 _rels/.rels
?rw-------  2.0 unx      556 b- defN 80-Jan-01 00:00 xl/_rels/workbook.xml.rels
9 files, 12477 bytes uncompressed, 3924 bytes compressed:  68.6%
```

Fixes #573.