### PR TITLE
Page view can be set to 'pageBreakPreview'

### DIFF
--- a/dev/docs/source/page_setup.rst
+++ b/dev/docs/source/page_setup.rst
@@ -44,13 +44,14 @@ generally need to call this method::
 worksheet.set_page_view()
 -------------------------
 
-.. py:function:: set_page_view()
+.. py:function:: set_page_view([view="pageLayout"])
 
    Set the page view mode.
 
-This method is used to display the worksheet in "Page View/Layout" mode::
+This method is used to display the worksheet in "Page View/Layout" or "Page Break Preview" mode::
 
     worksheet.set_page_view()
+    worksheet.set_page_view("pageBreakPreview")
 
 
 worksheet.set_paper()

--- a/xlsxwriter/test/worksheet/test_write_sheet_views1.py
+++ b/xlsxwriter/test/worksheet/test_write_sheet_views1.py
@@ -92,3 +92,27 @@ class TestWriteSheetViews(unittest.TestCase):
         got = self.fh.getvalue()
 
         self.assertEqual(got, exp)
+
+    def test_write_sheet_views_page_view_page_layout(self):
+        """Test the _write_sheet_views() method"""
+
+        self.worksheet.select()
+        self.worksheet.set_page_view("pageLayout")
+        self.worksheet._write_sheet_views()
+
+        exp = """<sheetViews><sheetView tabSelected="1" view="pageLayout" workbookViewId="0"/></sheetViews>"""
+        got = self.fh.getvalue()
+
+        self.assertEqual(got, exp)
+
+    def test_write_sheet_views_page_view_page_break_preview(self):
+        """Test the _write_sheet_views() method"""
+
+        self.worksheet.select()
+        self.worksheet.set_page_view("pageBreakPreview")
+        self.worksheet._write_sheet_views()
+
+        exp = """<sheetViews><sheetView tabSelected="1" view="pageBreakPreview" workbookViewId="0"/></sheetViews>"""
+        got = self.fh.getvalue()
+
+        self.assertEqual(got, exp)

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -352,7 +352,7 @@ class Worksheet(xmlwriter.XMLwriter):
         self.data_bars_2010 = []
         self.use_data_bars_2010 = False
         self.dxf_priority = 1
-        self.page_view = 0
+        self.page_view = None
 
         self.vba_codename = None
 
@@ -3620,18 +3620,18 @@ class Worksheet(xmlwriter.XMLwriter):
         self.orientation = 1
         self.page_setup_changed = True
 
-    def set_page_view(self):
+    def set_page_view(self, view="pageLayout"):
         """
         Set the page view mode.
 
         Args:
-            None.
+            view: to be used as attribute for the 'sheetView' xml tag
 
         Returns:
             Nothing.
 
         """
-        self.page_view = 1
+        self.page_view = view
 
     def set_paper(self, paper_size):
         """
@@ -5733,7 +5733,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Set the page view/layout mode if required.
         if self.page_view:
-            attributes.append(('view', 'pageLayout'))
+            attributes.append(('view', self.page_view))
 
         # Set the first visible cell.
         if self.top_left_cell != '':


### PR DESCRIPTION
This commit adds the optional argument `view` to `Worksheet.set_page_view(self, view="pageLayout")` to enable the user to select other page views such as `"pageBreakPreview"`.

This commit does not change the API in any way. Two test functions have been added and the documentation was updated.

Fixes #575 