### PR TITLE
Docs: drop quotes around list of invalid characters

### DIFF
--- a/dev/docs/source/exceptions.rst
+++ b/dev/docs/source/exceptions.rst
@@ -129,7 +129,7 @@ Raises::
         must be <= 31 chars.
 
 Or for a worksheet name containing one of the Excel restricted characters,
-i.e. ``' [ ] : * ? / \'``::
+i.e. ``[ ] : * ? / \``::
 
     import xlsxwriter
 

--- a/dev/docs/source/workbook.rst
+++ b/dev/docs/source/workbook.rst
@@ -186,7 +186,7 @@ default Excel convention will be followed, i.e. Sheet1, Sheet2, etc.::
 .. image:: _images/workbook02.png
 
 The worksheet name must be a valid Excel worksheet name, i.e. it cannot
-contain any of the characters ``' [ ] : * ? / \'`` and it must be less than 32
+contain any of the characters ``[ ] : * ? / \`` and it must be less than 32
 characters. These errors will raise a :exc:`InvalidWorksheetName` exception.
 
 In addition, you cannot use the same, case insensitive, ``name`` for more than
@@ -293,8 +293,8 @@ The ``sheetname`` parameter is optional. If it is not specified the default
 Excel convention will be followed, i.e. Chart1, Chart2, etc.
 
 The chartsheet name must be a valid Excel worksheet name, i.e. it cannot
-contain any of the characters ``' [ ] : * ? / \
-'`` and it must be less than 32 characters.
+contain any of the characters ``[ ] : * ? / \`` and it must be less than 32
+characters.
 
 In addition, you cannot use the same, case insensitive, ``sheetname`` for more
 than one chartsheet.


### PR DESCRIPTION
These are already quoted using \`\`...\`\`, and the apostrophes make it appear that `'` itself is an invalid character in a worksheet name.