### PR TITLE
add warnings for sheets with invalid dimensions

### DIFF
--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -510,8 +510,7 @@ class Worksheet(xmlwriter.XMLwriter):
         # Check that row and col are valid and store max and min values.
         if self._check_dimensions(row, col):
             warn('Cannot write string at (%d, %d): \
-                  invalid dimensions (out of range).' 
-                  % (row, col))
+                  invalid dimensions (out of range).' % (row, col))
             return -1
 
         # Check that the string is < 32767 chars.
@@ -571,8 +570,7 @@ class Worksheet(xmlwriter.XMLwriter):
         # Check that row and col are valid and store max and min values.
         if self._check_dimensions(row, col):
             warn('Cannot write number at (%d, %d): \
-                  invalid dimensions (out of range).' \
-                  % (row, col))
+                  invalid dimensions (out of range).' % (row, col))
             return -1
 
         # Write previous row if in in-line string constant_memory mode.
@@ -612,8 +610,7 @@ class Worksheet(xmlwriter.XMLwriter):
         # Check that row and col are valid and store max and min values.
         if self._check_dimensions(row, col):
             warn('Cannot write blank cell at (%d, %d): \
-                  invalid dimensions (out of range).' \
-                  % (row, col))
+                  invalid dimensions (out of range).' % (row, col))
             return -1
 
         # Write previous row if in in-line string constant_memory mode.
@@ -649,8 +646,7 @@ class Worksheet(xmlwriter.XMLwriter):
     def _write_formula(self, row, col, formula, cell_format=None, value=0):
         if self._check_dimensions(row, col):
             warn('Cannot write formula at (%d, %d): \
-                  invalid dimensions (out of range).' \
-                  % (row, col))
+                  invalid dimensions (out of range).' % (row, col))
             return -1
 
         # Hand off array formulas.
@@ -707,7 +703,7 @@ class Worksheet(xmlwriter.XMLwriter):
         # Check that row and col are valid and store max and min values
         if self._check_dimensions(last_row, last_col):
             warn('Cannot write array formula at (%d, %d): \
-                  invalid dimensions (out of range).' \
+                  invalid dimensions (out of range).'
                   % (last_row, last_col))
             return -1
 
@@ -769,8 +765,7 @@ class Worksheet(xmlwriter.XMLwriter):
         # Check that row and col are valid and store max and min values.
         if self._check_dimensions(row, col):
             warn('Cannot write date/time at (%d, %d): \
-                  invalid dimensions (out of range).' \
-                  % (row, col))
+                  invalid dimensions (out of range).' % (row, col))
             return -1
 
         # Write previous row if in in-line string constant_memory mode.
@@ -813,8 +808,7 @@ class Worksheet(xmlwriter.XMLwriter):
         # Check that row and col are valid and store max and min values.
         if self._check_dimensions(row, col):
             warn('Cannot write boolean value at (%d, %d): \
-                  invalid dimensions (out of range).' \
-                  % (row, col))
+                  invalid dimensions (out of range).' % (row, col))
             return -1
 
         # Write previous row if in in-line string constant_memory mode.
@@ -868,8 +862,7 @@ class Worksheet(xmlwriter.XMLwriter):
         # Check that row and col are valid and store max and min values
         if self._check_dimensions(row, col):
             warn('Cannot write url at (%d, %d): \
-                  invalid dimensions (out of range).' \
-                % (row, col))
+                  invalid dimensions (out of range).' % (row, col))
             return -1
 
         # Set the displayed string to the URL unless defined by the user.
@@ -1001,8 +994,7 @@ class Worksheet(xmlwriter.XMLwriter):
         # Check that row and col are valid and store max and min values
         if self._check_dimensions(row, col):
             warn('Cannot write rich string at (%d, %d): \
-                  invalid dimensions (out of range).' \
-                  % (row, col))
+                  invalid dimensions (out of range).' % (row, col))
             return -1
 
         # If the last arg is a format we use it as the cell format.
@@ -1309,8 +1301,7 @@ class Worksheet(xmlwriter.XMLwriter):
         # Check that row and col are valid and store max and min values
         if self._check_dimensions(row, col):
             warn('Cannot write comment at (%d, %d): \
-                  invalid dimensions (out of range).' \
-                  % (row, col))
+                  invalid dimensions (out of range).' % (row, col))
             return -1
 
         # Check that the comment string is < 32767 chars.
@@ -1481,8 +1472,7 @@ class Worksheet(xmlwriter.XMLwriter):
             return -1
         if self._check_dimensions(0, first_col, ignore_row, ignore_col):
             warn('Cannot set column at %d: \
-                  invalid dimensions (out of range).' \
-                  % first_col)
+                  invalid dimensions (out of range).' % first_col)
             return -1
 
         # Set the limits for the outline levels (0 <= x <= 7).
@@ -1541,8 +1531,7 @@ class Worksheet(xmlwriter.XMLwriter):
         # Check that row is valid.
         if self._check_dimensions(row, min_col):
             warn('Cannot set row at %d: \
-                  invalid dimensions (out of range).' \
-                  % row)
+                  invalid dimensions (out of range).' % row)
             return -1
 
         if height is None:
@@ -1636,7 +1625,7 @@ class Worksheet(xmlwriter.XMLwriter):
         # Check that column number is valid and store the max value
         if self._check_dimensions(last_row, last_col) == -1:
             warn('Cannot merge cell at (%d, %d): \
-                  invalid dimensions (out of range).' \
+                  invalid dimensions (out of range).'
                   % (last_row, last_col))
             return
 
@@ -1805,7 +1794,7 @@ class Worksheet(xmlwriter.XMLwriter):
             return -1
         if self._check_dimensions(last_row, last_col, True, True):
             warn('Cannot add data validation at (%d, %d): \
-                  invalid dimensions (out of range).' \
+                  invalid dimensions (out of range).'
                   % (last_row, last_col))
             return -1
 
@@ -2043,7 +2032,7 @@ class Worksheet(xmlwriter.XMLwriter):
             return -1
         if self._check_dimensions(last_row, last_col, True, True):
             warn('Cannot add conditional format at (%d, %d): \
-                  invalid dimensions (out of range).' \
+                  invalid dimensions (out of range).'
                   % (last_row, last_col))
             return -1
 
@@ -2549,7 +2538,7 @@ class Worksheet(xmlwriter.XMLwriter):
             return -2 
         if self._check_dimensions(last_row, last_col, True, True):
             warn('Cannot add table at (%d, %d): \
-                  invalid dimensions (out of range).' \
+                  invalid dimensions (out of range).'
                   % (last_row, last_col))
             return -2
 
@@ -2811,8 +2800,7 @@ class Worksheet(xmlwriter.XMLwriter):
         # Check that row and col are valid without storing the values.
         if self._check_dimensions(row, col, True, True):
             warn('Cannot add sparkline at (%d, %d): \
-                  invalid dimensions (out of range).' \
-                  % (row, col))
+                  invalid dimensions (out of range).' % (row, col))
             return -1
 
         sparkline = {'locations': [xl_rowcol_to_cell(row, col)]}

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -509,7 +509,9 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values.
         if self._check_dimensions(row, col):
-            warn('Cannot write string at (%d, %d): invalid dimensions (out of range).' % (row, col))
+            warn('Cannot write string at (%d, %d): \
+                  invalid dimensions (out of range).' 
+                  % (row, col))
             return -1
 
         # Check that the string is < 32767 chars.
@@ -568,7 +570,9 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values.
         if self._check_dimensions(row, col):
-            warn('Cannot write number at (%d, %d): invalid dimensions (out of range).' % (row, col))
+            warn('Cannot write number at (%d, %d): \
+                  invalid dimensions (out of range).' \
+                  % (row, col))
             return -1
 
         # Write previous row if in in-line string constant_memory mode.
@@ -607,7 +611,9 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values.
         if self._check_dimensions(row, col):
-            warn('Cannot write blank cell at (%d, %d): invalid dimensions (out of range).' % (row, col))
+            warn('Cannot write blank cell at (%d, %d): \
+                  invalid dimensions (out of range).' \
+                  % (row, col))
             return -1
 
         # Write previous row if in in-line string constant_memory mode.
@@ -642,7 +648,9 @@ class Worksheet(xmlwriter.XMLwriter):
     # Undecorated version of write_formula().
     def _write_formula(self, row, col, formula, cell_format=None, value=0):
         if self._check_dimensions(row, col):
-            warn('Cannot write formula at (%d, %d): invalid dimensions (out of range).' % (row, col))
+            warn('Cannot write formula at (%d, %d): \
+                  invalid dimensions (out of range).' \
+                  % (row, col))
             return -1
 
         # Hand off array formulas.
@@ -698,7 +706,9 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values
         if self._check_dimensions(last_row, last_col):
-            warn('Cannot write array formula at (%d, %d): invalid dimensions (out of range).' % (last_row, last_col))
+            warn('Cannot write array formula at (%d, %d): \
+                  invalid dimensions (out of range).' \
+                  % (last_row, last_col))
             return -1
 
         # Define array range
@@ -758,7 +768,9 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values.
         if self._check_dimensions(row, col):
-            warn('Cannot write date/time at (%d, %d): invalid dimensions (out of range).' % (row, col))
+            warn('Cannot write date/time at (%d, %d): \
+                  invalid dimensions (out of range).' \
+                  % (row, col))
             return -1
 
         # Write previous row if in in-line string constant_memory mode.
@@ -800,7 +812,9 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values.
         if self._check_dimensions(row, col):
-            warn('Cannot write boolean value at (%d, %d): invalid dimensions (out of range).' % (row, col))
+            warn('Cannot write boolean value at (%d, %d): \
+                  invalid dimensions (out of range).' \
+                  % (row, col))
             return -1
 
         # Write previous row if in in-line string constant_memory mode.
@@ -853,7 +867,9 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values
         if self._check_dimensions(row, col):
-            warn('Cannot write url at (%d, %d): invalid dimensions (out of range).' % (row, col))
+            warn('Cannot write url at (%d, %d): \
+                  invalid dimensions (out of range).' \
+                % (row, col))
             return -1
 
         # Set the displayed string to the URL unless defined by the user.
@@ -984,7 +1000,9 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values
         if self._check_dimensions(row, col):
-            warn('Cannot write rich string at (%d, %d): invalid dimensions (out of range).' % (row, col))
+            warn('Cannot write rich string at (%d, %d): \
+                  invalid dimensions (out of range).' \
+                  % (row, col))
             return -1
 
         # If the last arg is a format we use it as the cell format.
@@ -1290,7 +1308,9 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values
         if self._check_dimensions(row, col):
-            warn('Cannot write comment at (%d, %d): invalid dimensions (out of range).' % (row, col))
+            warn('Cannot write comment at (%d, %d): \
+                  invalid dimensions (out of range).' \
+                  % (row, col))
             return -1
 
         # Check that the comment string is < 32767 chars.
@@ -1460,7 +1480,9 @@ class Worksheet(xmlwriter.XMLwriter):
         if self._check_dimensions(0, last_col, ignore_row, ignore_col):
             return -1
         if self._check_dimensions(0, first_col, ignore_row, ignore_col):
-            warn('Cannot set column at %d: invalid dimensions (out of range).' % first_col)
+            warn('Cannot set column at %d: \
+                  invalid dimensions (out of range).' \
+                  % first_col)
             return -1
 
         # Set the limits for the outline levels (0 <= x <= 7).
@@ -1518,7 +1540,9 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row is valid.
         if self._check_dimensions(row, min_col):
-            warn('Cannot set row at %d: invalid dimensions (out of range).' % row)
+            warn('Cannot set row at %d: \
+                  invalid dimensions (out of range).' \
+                  % row)
             return -1
 
         if height is None:
@@ -1611,7 +1635,9 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that column number is valid and store the max value
         if self._check_dimensions(last_row, last_col) == -1:
-            warn('Cannot merge cell at (%d, %d): invalid dimensions (out of range).' % (last_row, last_col))
+            warn('Cannot merge cell at (%d, %d): \
+                  invalid dimensions (out of range).' \
+                  % (last_row, last_col))
             return
 
         # Store the merge range.
@@ -1778,7 +1804,9 @@ class Worksheet(xmlwriter.XMLwriter):
         if self._check_dimensions(first_row, first_col, True, True):
             return -1
         if self._check_dimensions(last_row, last_col, True, True):
-            warn('Cannot add data validation at (%d, %d): invalid dimensions (out of range).' % (last_row, last_col))
+            warn('Cannot add data validation at (%d, %d): \
+                  invalid dimensions (out of range).' \
+                  % (last_row, last_col))
             return -1
 
         if options is None:
@@ -2014,7 +2042,9 @@ class Worksheet(xmlwriter.XMLwriter):
         if self._check_dimensions(first_row, first_col, True, True):
             return -1
         if self._check_dimensions(last_row, last_col, True, True):
-            warn('Cannot add conditional format at (%d, %d): invalid dimensions (out of range).' % (last_row, last_col))
+            warn('Cannot add conditional format at (%d, %d): \
+                  invalid dimensions (out of range).' \
+                  % (last_row, last_col))
             return -1
 
         if options is None:
@@ -2518,7 +2548,9 @@ class Worksheet(xmlwriter.XMLwriter):
         if self._check_dimensions(first_row, first_col, True, True):
             return -2 
         if self._check_dimensions(last_row, last_col, True, True):
-            warn('Cannot add table at (%d, %d): invalid dimensions (out of range).' % (last_row, last_col))
+            warn('Cannot add table at (%d, %d): \
+                  invalid dimensions (out of range).' \
+                  % (last_row, last_col))
             return -2
 
         # Valid input parameters.
@@ -2778,7 +2810,9 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid without storing the values.
         if self._check_dimensions(row, col, True, True):
-            warn('Cannot add sparkline at (%d, %d): invalid dimensions (out of range).' % (row, col))
+            warn('Cannot add sparkline at (%d, %d): \
+                  invalid dimensions (out of range).' \
+                  % (row, col))
             return -1
 
         sparkline = {'locations': [xl_rowcol_to_cell(row, col)]}

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -509,6 +509,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values.
         if self._check_dimensions(row, col):
+            warn('Cannot write string at (%d, %d): invalid dimensions (out of range).' % (row, col))
             return -1
 
         # Check that the string is < 32767 chars.
@@ -567,6 +568,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values.
         if self._check_dimensions(row, col):
+            warn('Cannot write number at (%d, %d): invalid dimensions (out of range).' % (row, col))
             return -1
 
         # Write previous row if in in-line string constant_memory mode.
@@ -605,6 +607,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values.
         if self._check_dimensions(row, col):
+            warn('Cannot write blank cell at (%d, %d): invalid dimensions (out of range).' % (row, col))
             return -1
 
         # Write previous row if in in-line string constant_memory mode.
@@ -639,6 +642,7 @@ class Worksheet(xmlwriter.XMLwriter):
     # Undecorated version of write_formula().
     def _write_formula(self, row, col, formula, cell_format=None, value=0):
         if self._check_dimensions(row, col):
+            warn('Cannot write formula at (%d, %d): invalid dimensions (out of range).' % (row, col))
             return -1
 
         # Hand off array formulas.
@@ -694,6 +698,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values
         if self._check_dimensions(last_row, last_col):
+            warn('Cannot write array formula at (%d, %d): invalid dimensions (out of range).' % (row, col))
             return -1
 
         # Define array range
@@ -753,6 +758,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values.
         if self._check_dimensions(row, col):
+            warn('Cannot write date/time at (%d, %d): invalid dimensions (out of range).' % (row, col))
             return -1
 
         # Write previous row if in in-line string constant_memory mode.
@@ -794,6 +800,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values.
         if self._check_dimensions(row, col):
+            warn('Cannot write boolean value at (%d, %d): invalid dimensions (out of range).' % (row, col))
             return -1
 
         # Write previous row if in in-line string constant_memory mode.
@@ -846,6 +853,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values
         if self._check_dimensions(row, col):
+            warn('Cannot write url at (%d, %d): invalid dimensions (out of range).' % (row, col))
             return -1
 
         # Set the displayed string to the URL unless defined by the user.
@@ -976,6 +984,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values
         if self._check_dimensions(row, col):
+            warn('Cannot write rich string at (%d, %d): invalid dimensions (out of range).' % (row, col))
             return -1
 
         # If the last arg is a format we use it as the cell format.
@@ -1281,6 +1290,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values
         if self._check_dimensions(row, col):
+            warn('Cannot write comment at (%d, %d): invalid dimensions (out of range).' % (row, col))
             return -1
 
         # Check that the comment string is < 32767 chars.
@@ -1447,9 +1457,8 @@ class Worksheet(xmlwriter.XMLwriter):
             ignore_col = True
 
         # Check that each column is valid and store the max and min values.
-        if self._check_dimensions(0, last_col, ignore_row, ignore_col):
-            return -1
-        if self._check_dimensions(0, first_col, ignore_row, ignore_col):
+        if self._check_dimensions(0, last_col, ignore_row, ignore_col) or self._check_dimensions(0, first_col, ignore_row, ignore_col):
+            warn('Cannot set column at %d: invalid dimensions (out of range).' % col)
             return -1
 
         # Set the limits for the outline levels (0 <= x <= 7).
@@ -1507,6 +1516,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row is valid.
         if self._check_dimensions(row, min_col):
+            warn('Cannot set row at %d: invalid dimensions (out of range).' % row)
             return -1
 
         if height is None:
@@ -1599,6 +1609,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that column number is valid and store the max value
         if self._check_dimensions(last_row, last_col) == -1:
+            warn('Cannot merge cell at (%d, %d): invalid dimensions (out of range).' % (row, col))
             return
 
         # Store the merge range.
@@ -1762,9 +1773,8 @@ class Worksheet(xmlwriter.XMLwriter):
             -2: Incorrect parameter or option.
         """
         # Check that row and col are valid without storing the values.
-        if self._check_dimensions(first_row, first_col, True, True):
-            return -1
-        if self._check_dimensions(last_row, last_col, True, True):
+        if self._check_dimensions(first_row, first_col, True, True) or self._check_dimensions(last_row, last_col, True, True):
+            warn('Cannot add data validation at (%d, %d): invalid dimensions (out of range).' % (row, col))
             return -1
 
         if options is None:
@@ -1997,9 +2007,8 @@ class Worksheet(xmlwriter.XMLwriter):
             -2: Incorrect parameter or option.
         """
         # Check that row and col are valid without storing the values.
-        if self._check_dimensions(first_row, first_col, True, True):
-            return -1
-        if self._check_dimensions(last_row, last_col, True, True):
+        if self._check_dimensions(first_row, first_col, True, True) or self._check_dimensions(last_row, last_col, True, True):
+            warn('Cannot add conditional format at (%d, %d): invalid dimensions (out of range).' % (row, col))
             return -1
 
         if options is None:
@@ -2500,9 +2509,8 @@ class Worksheet(xmlwriter.XMLwriter):
             return -1
 
         # Check that row and col are valid without storing the values.
-        if self._check_dimensions(first_row, first_col, True, True):
-            return -2
-        if self._check_dimensions(last_row, last_col, True, True):
+        if self._check_dimensions(first_row, first_col, True, True) or self._check_dimensions(last_row, last_col, True, True):
+            warn('Cannot add table at (%d, %d): invalid dimensions (out of range).' % (row, col))
             return -2
 
         # Valid input parameters.
@@ -2762,6 +2770,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid without storing the values.
         if self._check_dimensions(row, col, True, True):
+            warn('Cannot add sparkline at (%d, %d): invalid dimensions (out of range).' % (row, col))
             return -1
 
         sparkline = {'locations': [xl_rowcol_to_cell(row, col)]}

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -698,7 +698,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid and store max and min values
         if self._check_dimensions(last_row, last_col):
-            warn('Cannot write array formula at (%d, %d): invalid dimensions (out of range).' % (row, col))
+            warn('Cannot write array formula at (%d, %d): invalid dimensions (out of range).' % (last_row, last_col))
             return -1
 
         # Define array range
@@ -1457,8 +1457,10 @@ class Worksheet(xmlwriter.XMLwriter):
             ignore_col = True
 
         # Check that each column is valid and store the max and min values.
-        if self._check_dimensions(0, last_col, ignore_row, ignore_col) or self._check_dimensions(0, first_col, ignore_row, ignore_col):
-            warn('Cannot set column at %d: invalid dimensions (out of range).' % col)
+        if self._check_dimensions(0, last_col, ignore_row, ignore_col):
+            return -1
+        if self._check_dimensions(0, first_col, ignore_row, ignore_col):
+            warn('Cannot set column at %d: invalid dimensions (out of range).' % first_col)
             return -1
 
         # Set the limits for the outline levels (0 <= x <= 7).
@@ -1609,7 +1611,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that column number is valid and store the max value
         if self._check_dimensions(last_row, last_col) == -1:
-            warn('Cannot merge cell at (%d, %d): invalid dimensions (out of range).' % (row, col))
+            warn('Cannot merge cell at (%d, %d): invalid dimensions (out of range).' % (last_row, last_col))
             return
 
         # Store the merge range.
@@ -1773,8 +1775,10 @@ class Worksheet(xmlwriter.XMLwriter):
             -2: Incorrect parameter or option.
         """
         # Check that row and col are valid without storing the values.
-        if self._check_dimensions(first_row, first_col, True, True) or self._check_dimensions(last_row, last_col, True, True):
-            warn('Cannot add data validation at (%d, %d): invalid dimensions (out of range).' % (row, col))
+        if self._check_dimensions(first_row, first_col, True, True):
+            return -1
+        if self._check_dimensions(last_row, last_col, True, True):
+            warn('Cannot add data validation at (%d, %d): invalid dimensions (out of range).' % (last_row, last_col))
             return -1
 
         if options is None:
@@ -2007,8 +2011,10 @@ class Worksheet(xmlwriter.XMLwriter):
             -2: Incorrect parameter or option.
         """
         # Check that row and col are valid without storing the values.
-        if self._check_dimensions(first_row, first_col, True, True) or self._check_dimensions(last_row, last_col, True, True):
-            warn('Cannot add conditional format at (%d, %d): invalid dimensions (out of range).' % (row, col))
+        if self._check_dimensions(first_row, first_col, True, True):
+            return -1
+        if self._check_dimensions(last_row, last_col, True, True):
+            warn('Cannot add conditional format at (%d, %d): invalid dimensions (out of range).' % (last_row, last_col))
             return -1
 
         if options is None:
@@ -2509,8 +2515,10 @@ class Worksheet(xmlwriter.XMLwriter):
             return -1
 
         # Check that row and col are valid without storing the values.
-        if self._check_dimensions(first_row, first_col, True, True) or self._check_dimensions(last_row, last_col, True, True):
-            warn('Cannot add table at (%d, %d): invalid dimensions (out of range).' % (row, col))
+        if self._check_dimensions(first_row, first_col, True, True):
+            return -2 
+        if self._check_dimensions(last_row, last_col, True, True):
+            warn('Cannot add table at (%d, %d): invalid dimensions (out of range).' % (last_row, last_col))
             return -2
 
         # Valid input parameters.

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -704,7 +704,7 @@ class Worksheet(xmlwriter.XMLwriter):
         if self._check_dimensions(last_row, last_col):
             warn('Cannot write array formula at (%d, %d): \
                   invalid dimensions (out of range).'
-                  % (last_row, last_col))
+                % (last_row, last_col))
             return -1
 
         # Define array range
@@ -1626,7 +1626,7 @@ class Worksheet(xmlwriter.XMLwriter):
         if self._check_dimensions(last_row, last_col) == -1:
             warn('Cannot merge cell at (%d, %d): \
                   invalid dimensions (out of range).'
-                  % (last_row, last_col))
+                % (last_row, last_col))
             return
 
         # Store the merge range.
@@ -1795,7 +1795,7 @@ class Worksheet(xmlwriter.XMLwriter):
         if self._check_dimensions(last_row, last_col, True, True):
             warn('Cannot add data validation at (%d, %d): \
                   invalid dimensions (out of range).'
-                  % (last_row, last_col))
+                % (last_row, last_col))
             return -1
 
         if options is None:
@@ -2033,7 +2033,7 @@ class Worksheet(xmlwriter.XMLwriter):
         if self._check_dimensions(last_row, last_col, True, True):
             warn('Cannot add conditional format at (%d, %d): \
                   invalid dimensions (out of range).'
-                  % (last_row, last_col))
+                % (last_row, last_col))
             return -1
 
         if options is None:
@@ -2535,11 +2535,11 @@ class Worksheet(xmlwriter.XMLwriter):
 
         # Check that row and col are valid without storing the values.
         if self._check_dimensions(first_row, first_col, True, True):
-            return -2 
+            return -2
         if self._check_dimensions(last_row, last_col, True, True):
             warn('Cannot add table at (%d, %d): \
                   invalid dimensions (out of range).'
-                  % (last_row, last_col))
+                % (last_row, last_col))
             return -2
 
         # Valid input parameters.


### PR DESCRIPTION
Invalid sheets with too large dimensions:
- (row, col) > (1048576, 16384)

Raise warning messages when these large sheets are involved.
issue tracker: #620


