### PR TITLE
Fix python SyntaxError

### DIFF
--- a/xlsxwriter/chart.py
+++ b/xlsxwriter/chart.py
@@ -2494,10 +2494,10 @@ class Chart(xmlwriter.XMLwriter):
         if val is None:
             val = 'ctr'
 
-        if val is 'right':
+        if val == 'right':
             val = 'r'
 
-        if val is 'left':
+        if val == 'left':
             val = 'l'
 
         attributes = [('val', val)]

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -360,7 +360,7 @@ class Worksheet(xmlwriter.XMLwriter):
     # Utility function for writing different types of strings.
     def _write_token_as_string(self, token, row, col, *args):
         # Map the data to the appropriate write_*() method.
-        if token is '':
+        if token == '':
             return self._write_blank(row, col, *args)
 
         if self.strings_to_formulas and token.startswith('='):
@@ -2469,10 +2469,10 @@ class Worksheet(xmlwriter.XMLwriter):
         if options.get('is_data_bar_2010'):
             self.excel_version = 2010
 
-            if options['min_type'] is 'min' and options['min_value'] == 0:
+            if options['min_type'] == 'min' and options['min_value'] == 0:
                 options['min_value'] = None
 
-            if options['max_type'] is 'max' and options['max_value'] == 0:
+            if options['max_type'] == 'max' and options['max_value'] == 0:
                 options['max_value'] = None
 
             options['range'] = cell_range
@@ -5040,7 +5040,7 @@ class Worksheet(xmlwriter.XMLwriter):
                     else:
                         props[i]['type'] = user_props[i]['type']
 
-                        if props[i]['type'] is 'number':
+                        if props[i]['type'] == 'number':
                             props[i]['type'] = 'num'
 
                 # Set the user defined 'criteria' property.
@@ -6903,10 +6903,10 @@ class Worksheet(xmlwriter.XMLwriter):
         if data_bar['bar_solid']:
             attributes.append(('gradient', 0))
 
-        if data_bar['bar_direction'] is 'left':
+        if data_bar['bar_direction'] == 'left':
             attributes.append(('direction', 'leftToRight'))
 
-        if data_bar['bar_direction'] is 'right':
+        if data_bar['bar_direction'] == 'right':
             attributes.append(('direction', 'rightToLeft'))
 
         if data_bar['bar_negative_color_same']:
@@ -6916,10 +6916,10 @@ class Worksheet(xmlwriter.XMLwriter):
                 not data_bar['bar_negative_border_color_same']):
             attributes.append(('negativeBarBorderColorSameAsPositive', 0))
 
-        if data_bar['bar_axis_position'] is 'middle':
+        if data_bar['bar_axis_position'] == 'middle':
             attributes.append(('axisPosition', 'middle'))
 
-        if data_bar['bar_axis_position'] is 'none':
+        if data_bar['bar_axis_position'] == 'none':
             attributes.append(('axisPosition', 'none'))
 
         self._xml_start_tag('x14:dataBar', attributes)

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -6868,7 +6868,7 @@ class Worksheet(xmlwriter.XMLwriter):
                 data_bar['bar_negative_border_color'])
 
         # Write the x14:axisColor element.
-        if data_bar['bar_axis_position'] is not 'none':
+        if data_bar['bar_axis_position'] != 'none':
             self._write_x14_axis_color(data_bar['bar_axis_color'])
 
         self._xml_end_tag('x14:dataBar')


### PR DESCRIPTION
So the output from a python 3.8 program using XlsxWriter will now output
```
c:\program files\python38\lib\site-packages\xlsxwriter-1.2.1-py3.8.egg\xlsxwriter\worksheet.py:363: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if token is '':
c:\program files\python38\lib\site-packages\xlsxwriter-1.2.1-py3.8.egg\xlsxwriter\worksheet.py:2472: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if options['min_type'] is 'min' and options['min_value'] == 0:
```
etc, due to incorrect comparison to a literal with `is` operator, which still works but is incorrect use.

I've ran `make test` which under Win10 reports 3 errors but I don't believe these to be due to the changes.

Closes #660 