### PR TITLE
Bugfix/close file handles

### DIFF
--- a/xlsxwriter/test/workbook/test_close.py
+++ b/xlsxwriter/test/workbook/test_close.py
@@ -5,7 +5,10 @@
 # Copyright (c), 2013-2020, John McNamara, jmcnamara@cpan.org
 #
 
+import os
+import tempfile
 import unittest
+import warnings
 from ...workbook import Workbook
 from ...exceptions import FileCreateError
 
@@ -23,3 +26,16 @@ class TestCloseWithException(unittest.TestCase):
 
         with self.assertRaises(FileCreateError):
             self.workbook.close()
+
+    def test_workbook_closes_all_handles(self):
+        """Test that close() closes all file handles"""
+
+        filepath = tempfile.mktemp()
+
+        with warnings.catch_warnings(record=True) as warnings_emitted:
+            workbook = Workbook(filepath, dict(constant_memory=True))
+            workbook.close()
+            del workbook
+
+        os.unlink(filepath)
+        self.assertFalse(warnings_emitted)

--- a/xlsxwriter/workbook.py
+++ b/xlsxwriter/workbook.py
@@ -325,6 +325,12 @@ class Workbook(xmlwriter.XMLwriter):
                                     "Use workbook.use_zip64().")
 
             self.fileclosed = True
+
+            # Storing may cause constant_memory Worksheet to re-open files
+            # Ensure all file handles are closed out
+            if self.constant_memory:
+                for worksheet in self.worksheets():
+                    worksheet._opt_close()
         else:
             warn("Calling close() on already closed file.")
 


### PR DESCRIPTION
Workbooks using `constant_memory` option leak a file handle after close() and collected by GC

Proposed fix to issue [#764 ](https://github.com/jmcnamara/XlsxWriter/issues/764#issue-751042430)