### PR TITLE
Fix typo in insert_image() #819

### DIFF
--- a/dev/docs/source/worksheet.rst
+++ b/dev/docs/source/worksheet.rst
@@ -1234,13 +1234,13 @@ documentation on :func:`set_column` for more details.
 worksheet.insert_image()
 ------------------------
 
-.. py:function:: insert_image(row, col, image[, options])
+.. py:function:: insert_image(row, col, filename[, options])
 
    Insert an image in a worksheet cell.
 
    :param row:         The cell row (zero indexed).
    :param col:         The cell column (zero indexed).
-   :param image:       Image filename (with path if required).
+   :param filename:    Image filename (with path if required).
    :param options:     Optional parameters for image position, scale and url.
    :type  row:         int
    :type  col:         int


### PR DESCRIPTION
Fixed a small typo in the docs for `insert_image()`. Documentation now uses `filename` parameter rather than `image` for this function. 