### PR TITLE
Remove "r" attribute from "row" and "c" tag, to reduce file size

### DIFF
--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -6162,7 +6162,8 @@ class Worksheet(xmlwriter.XMLwriter):
         if height is None:
             height = self.default_row_height
 
-        attributes = [('r', row + 1)]
+        # Set initial empty attributes without r attr, to reduce file size
+        attributes = []
 
         # Get the cell_format index.
         if cell_format:
@@ -6211,7 +6212,8 @@ class Worksheet(xmlwriter.XMLwriter):
 
         cell_range = xl_rowcol_to_cell_fast(row, col)
 
-        attributes = [('r', cell_range)]
+        # Set initial empty attributes without r attr, to reduce file size
+        attributes = []
 
         if cell.format:
             # Add the cell format index.


### PR DESCRIPTION
Remove "r" attribute from "row" and "c" tag, to reduce file size.
If always put this attr for each row and col, file size for large sets of rows increase final file size over 5 times.
These attributes are optional for *.xlsx format