### PR TITLE
Remove "r" attribute from "row" and "c" tag, to reduce file size via append two new options dict elements

### DIFF
--- a/xlsxwriter/workbook.py
+++ b/xlsxwriter/workbook.py
@@ -84,6 +84,8 @@ class Workbook(xmlwriter.XMLwriter):
         self.excel2003_style = options.get('excel2003_style', False)
         self.remove_timezone = options.get('remove_timezone', False)
         self.use_future_functions = options.get('use_future_functions', False)
+        self.omit_row_r_attribute = options.get('omit_row_r_attribute', False)
+        self.omit_cell_r_attribute = options.get('omit_cell_r_attribute', False)
         self.default_format_properties = \
             options.get('default_format_properties', {})
 
@@ -777,6 +779,8 @@ class Workbook(xmlwriter.XMLwriter):
             'remove_timezone': self.remove_timezone,
             'max_url_length': self.max_url_length,
             'use_future_functions': self.use_future_functions,
+            'omit_row_r_attribute': self.omit_row_r_attribute,
+            'omit_cell_r_attribute': self.omit_cell_r_attribute,
         }
 
         worksheet._initialize(init_data)

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -4157,6 +4157,8 @@ class Worksheet(xmlwriter.XMLwriter):
         self.remove_timezone = init_data['remove_timezone']
         self.max_url_length = init_data['max_url_length']
         self.use_future_functions = init_data['use_future_functions']
+        self.omit_row_r_attribute = init_data['omit_row_r_attribute']
+        self.omit_cell_r_attribute = init_data['omit_cell_r_attribute']
 
         if self.excel2003_style:
             self.original_row_height = 12.75
@@ -6162,8 +6164,10 @@ class Worksheet(xmlwriter.XMLwriter):
         if height is None:
             height = self.default_row_height
 
-        # Set initial empty attributes without r attr, to reduce file size
-        attributes = []
+        if self.omit_row_r_attribute:
+            attributes = []
+        else:
+            attributes = [('r', row + 1)]
 
         # Get the cell_format index.
         if cell_format:
@@ -6212,8 +6216,10 @@ class Worksheet(xmlwriter.XMLwriter):
 
         cell_range = xl_rowcol_to_cell_fast(row, col)
 
-        # Set initial empty attributes without r attr, to reduce file size
-        attributes = []
+        if self.omit_cell_r_attribute:
+            attributes = []
+        else:
+            attributes = [('r', cell_range)]
 
         if cell.format:
             # Add the cell format index.

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -6162,7 +6162,8 @@ class Worksheet(xmlwriter.XMLwriter):
         if height is None:
             height = self.default_row_height
 
-        attributes = [('r', row + 1)]
+        # Set initial empty attributes without r attr, to reduce file size
+        attributes = []
 
         # Get the cell_format index.
         if cell_format:
@@ -6211,7 +6212,8 @@ class Worksheet(xmlwriter.XMLwriter):
 
         cell_range = xl_rowcol_to_cell_fast(row, col)
 
-        attributes = [('r', cell_range)]
+        # Set initial empty attributes without r attr, to reduce file size
+        attributes = []
 
         if cell.format:
             # Add the cell format index.


### PR DESCRIPTION
Remove "r" attribute from "row" and "c" tag, to reduce file size via append two new options dict elements (bool):
"omit_row_r_attribute" and "omit_cell_r_attribute"
If always put this attr for each row and col, file size for large sets of rows increase final file size over 5 times.
These attributes are optional for *.xlsx format