### PR TITLE
docs: Fix a few typos

### DIFF
--- a/dev/docs/source/_themes/bootstrap/static/js/jquery-1.9.1.js
+++ b/dev/docs/source/_themes/bootstrap/static/js/jquery-1.9.1.js
@@ -4186,7 +4186,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 		// Regex strategy adopted from Diego Perini
 		assert(function( div ) {
 			// Select is set to empty string on purpose
-			// This is to test IE's treatment of not explictly
+			// This is to test IE's treatment of not explicitly
 			// setting a boolean content attribute,
 			// since its presence should be enough
 			// http://bugs.jquery.com/ticket/12359
@@ -4854,7 +4854,7 @@ Expr = Sizzle.selectors = {
 		// The identifier C does not have to be a valid language name."
 		// http://www.w3.org/TR/selectors/#lang-pseudo
 		"lang": markFunction( function( lang ) {
-			// lang value must be a valid identifider
+			// lang value must be a valid identifier
 			if ( !ridentifier.test(lang || "") ) {
 				Sizzle.error( "unsupported lang: " + lang );
 			}


### PR DESCRIPTION
There are small typos in:
- dev/docs/source/_themes/bootstrap/static/js/jquery-1.9.1.js

Fixes:
- Should read `identifier` rather than `identifider`.
- Should read `explicitly` rather than `explictly`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md