### PR TITLE
Validation multi range

### DIFF
--- a/dev/docs/source/working_with_data_validation.rst
+++ b/dev/docs/source/working_with_data_validation.rst
@@ -87,6 +87,8 @@ main parameters are:
 +-------------------+-------------+------------+
 | ``show_error``    |             |            |
 +-------------------+-------------+------------+
+| ``multi_range``   |             |            |
++-------------------+-------------+------------+
 
 These parameters are explained in the following sections. Most of the
 parameters are optional, however, you will generally require the three main
@@ -352,6 +354,30 @@ after invalid data is entered' option in the Excel data validation dialog.
 When the option is off an error message is not displayed even if it has been
 set using ``error_message``. It is on by default.
 
+
+multi_range
+***********
+
+The ``multi_range`` option is used to extend a data validation over
+non-contiguous ranges.
+
+It is possible to apply the data validation to different cell ranges in a
+worksheet using multiple calls to ``data_validation()``. However, as a
+minor optimization it is also possible in Excel to apply the same data 
+validation to different non-contiguous cell ranges.
+
+This is replicated in ``data_validation()`` using the ``multi_range``
+option. The range must contain the primary range for the data validation
+and any others separated by spaces.
+
+For example to apply one data validation to two ranges, ``'B3:K6'`` and
+``'B9:K12'``::
+
+    worksheet.data_validation('B3:K6', {'validate': 'integer',
+                                        'criteria': 'between',
+                                        'minimum': 1,
+                                        'maximum': 100,
+                                        'multi_range': 'B3:K6 B9:K12'})
 
 
 Data Validation Examples

--- a/xlsxwriter/test/worksheet/test_write_data_validations02.py
+++ b/xlsxwriter/test/worksheet/test_write_data_validations02.py
@@ -963,3 +963,46 @@ class TestWriteDataValidations(unittest.TestCase):
         got = _xml_to_list(got)
 
         self.assertEqual(got, exp)
+
+    def test_write_data_validations_47(self):
+        """
+        Test 47 Check multi range with A1 style cell ranges.
+        """
+        self.worksheet.data_validation(4, 1, 9, 1, {'validate': 'integer',
+                                                    'criteria': 'between',
+                                                    'minimum': 1,
+                                                    'maximum': 10,
+                                                    'multi_range': 'B5:B10 D5:D10',
+                                                    })
+
+        self.worksheet._write_data_validations()
+
+        exp = '<dataValidations count="1"><dataValidation type="whole" allowBlank="1" showInputMessage="1" showErrorMessage="1" sqref="B5:B10 D5:D10"><formula1>1</formula1><formula2>10</formula2></dataValidation></dataValidations>'
+        got = self.fh.getvalue()
+
+        exp = _xml_to_list(exp)
+        got = _xml_to_list(got)
+
+        self.assertEqual(got, exp)
+
+    def test_write_data_validations_48(self):
+        """
+        Test 48 Check multi range with A1 style cells.
+        """
+        self.worksheet.data_validation(4, 1, 4, 1, {'validate': 'integer',
+                                                    'criteria': 'between',
+                                                    'minimum': 1,
+                                                    'maximum': 10,
+                                                    'other_cells': [[4, 3, 4, 3]],
+                                                    'multi_range': 'B5 C5',
+                                                    })
+
+        self.worksheet._write_data_validations()
+
+        exp = '<dataValidations count="1"><dataValidation type="whole" allowBlank="1" showInputMessage="1" showErrorMessage="1" sqref="B5 C5"><formula1>1</formula1><formula2>10</formula2></dataValidation></dataValidations>'
+        got = self.fh.getvalue()
+
+        exp = _xml_to_list(exp)
+        got = _xml_to_list(got)
+
+        self.assertEqual(got, exp)

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -2155,6 +2155,7 @@ class Worksheet(xmlwriter.XMLwriter):
             'error_message': True,
             'error_type': True,
             'other_cells': True,
+            'multi_range': True,
         }
 
         # Check for valid input parameters.
@@ -2337,6 +2338,10 @@ class Worksheet(xmlwriter.XMLwriter):
         # A (for now) undocumented parameter to pass additional cell ranges.
         if 'other_cells' in options:
             options['cells'].extend(options['other_cells'])
+
+        # Override with user defined multiple range if provided.
+        if 'multi_range' in options:
+            options['multi_range'] = options['multi_range'].replace('$', '')
 
         # Store the validation information until we close the worksheet.
         self.validations.append(options)
@@ -6899,6 +6904,9 @@ class Worksheet(xmlwriter.XMLwriter):
                 (col_first, col_last) = (col_last, col_first)
 
             sqref += xl_range(row_first, col_first, row_last, col_last)
+
+        if options.get('multi_range'):
+            sqref = options['multi_range']
 
         if options['validate'] != 'none':
             attributes.append(('type', options['validate']))


### PR DESCRIPTION
Adds a multi_range option to data_validation() to apply a validation rule to multiple non-contiguous cell ranges.

Includes two new test cases in test_write_data_validations02.py and documentation in working_with_data_validation.rst.

Reattempting after missing flake8 errors.

References https://github.com/jmcnamara/XlsxWriter/issues/874