### PR TITLE
Fix Bug: examples/pandas_multiple.py uses Deprecated function(=save)

### DIFF
--- a/examples/pandas_multiple.py
+++ b/examples/pandas_multiple.py
@@ -24,4 +24,4 @@ df2.to_excel(writer, sheet_name='Sheet2')
 df3.to_excel(writer, sheet_name='Sheet3')
 
 # Close the Pandas Excel writer and output the Excel file.
-writer.save()
+writer.close()


### PR DESCRIPTION
examples\pandas_multiple.py:27: FutureWarning: save is not part of the public API, usage can give unexpected results and will be removed in a future version

fixes #930
