### PR TITLE
Handle minor autofit edge-case (worksheet with no data)

### DIFF
--- a/xlsxwriter/test/comparison/test_autofit01.py
+++ b/xlsxwriter/test/comparison/test_autofit01.py
@@ -24,9 +24,12 @@ class TestCompareXLSXFiles(ExcelComparisonTest):
         """Test the creation of a simple XlsxWriter file."""
 
         workbook = Workbook(self.got_filename)
-
         worksheet = workbook.add_worksheet()
 
+        # Before writing data, nothing to autofit (should not raise)
+        worksheet.autofit()
+
+        # Write something that can be autofit
         worksheet.write_string(0, 0, "A")
 
         # Check for handling default/None width.

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -1835,6 +1835,10 @@ class Worksheet(xmlwriter.XMLwriter):
             warn("Autofit is not supported in constant_memory mode.")
             return
 
+        # No data written to the target sheet; nothing to autofit
+        if self.dim_rowmax is None:
+            return
+
         # Store the max pixel width for each column.
         col_width_max = {}
 


### PR DESCRIPTION
Closes #955, and adds some test coverage for the issue.

**Example:**
```python
from xlsxwriter import Workbook

with Workbook('test.xlsx') as wb:
    ws = wb.add_worksheet()
    ws.autofit()
```
**Before:**
```
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
```
**After:**
```
No exception raised
```