### PR TITLE
fix Bug: Using leader_lines leads to corrupted Excel

### DIFF
--- a/xlsxwriter/chart.py
+++ b/xlsxwriter/chart.py
@@ -3928,7 +3928,7 @@ class Chart(xmlwriter.XMLwriter):
 
         self._xml_start_tag("c:extLst")
         self._xml_start_tag("c:ext", attributes)
-        self._xml_empty_tag("<c15:showLeaderLines", [("val", 1)])
+        self._xml_empty_tag("c15:showLeaderLines", [("val", 1)])
         self._xml_end_tag("c:ext")
         self._xml_end_tag("c:extLst")
 


### PR DESCRIPTION
fixes #1019 