### PR TITLE
Add Argument Type Checks for Write.insert_image()

### DIFF
--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -1508,6 +1508,11 @@ class Worksheet(xmlwriter.XMLwriter):
             -1: Row or column is out of worksheet bounds.
 
         """
+        # Check if row is of type 'int'
+        if not isinstance(row, int):
+            warn("Argument 'row' must be of type 'int'. Was of type: '%d'" % (row))
+            return -1
+        
         # Check insert (row, col) without storing.
         if self._check_dimensions(row, col, True, True):
             warn("Cannot insert image at (%d, %d)." % (row, col))

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -1512,7 +1512,10 @@ class Worksheet(xmlwriter.XMLwriter):
         if not isinstance(row, int):
             warn("Argument 'row' must be of type 'int'. Was of type: '%d'" % (row))
             return -1
-        
+        # Check if col is of type 'int'
+        if not isinstance(col, int):
+            warn("Argument 'col' must be of type 'int'. Was of type: '%d'" % (row))
+            return -1
         # Check insert (row, col) without storing.
         if self._check_dimensions(row, col, True, True):
             warn("Cannot insert image at (%d, %d)." % (row, col))

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -1493,7 +1493,7 @@ class Worksheet(xmlwriter.XMLwriter):
         return 0
 
     @convert_cell_args
-    def insert_image(self, row, col, filename, options=None):
+    def insert_image(self, row: int , col: int, filename, options=None):
         """
         Insert an image with its top-left corner in a worksheet cell.
 


### PR DESCRIPTION
## Example
```python
# create workbook
workbook = xlsxwriter.Workbook(REPORT_PATH)
# create worksheet
worksheet = workbook.add_worksheet("Report")
# add image to worksheet
worksheet.insert_image(1, "A", FOOTER_PATH)

worksheet.autofit()

workbook.close()
```
This raises an error
```console
File "C:\Users\...\.venv\lib\site-packages\xlsxwriter\worksheet.py", line 4477, in _check_dimensions
    if row < 0 or col < 0:
TypeError: '<' not supported between instances of 'str' and 'int'
```
## Explanation
The reason for this addition is that the error trace for the argument type occurs in the `_check_dimensions()` comparison operand rather than in the parent function that calls it. Better error tracing and explanations make everyone happier!