### PR TITLE
Remove xlsx mention from the xlrd section

### DIFF
--- a/dev/docs/source/alternatives.rst
+++ b/dev/docs/source/alternatives.rst
@@ -39,5 +39,5 @@ XLRD
 
 From the `xlrd <https://xlrd.readthedocs.io/en/latest/>`_ documentation:
 
-   xlrd is a library for reading data and formatting information from older
-   Excel files (ie: .xls)
+  xlrd is a library for reading data and formatting information from Excel
+  files in the historical `.xls` format.

--- a/dev/docs/source/alternatives.rst
+++ b/dev/docs/source/alternatives.rst
@@ -39,5 +39,5 @@ XLRD
 
 From the `xlrd <https://xlrd.readthedocs.io/en/latest/>`_ documentation:
 
-   xlrd is a library for reading data and formatting information from Excel
-   files, whether they are .xls or .xlsx files.
+   xlrd is a library for reading data and formatting information from older
+   Excel files (ie: .xls)


### PR DESCRIPTION
xlrd removed xlsx support with the 2.0 release (https://xlrd.readthedocs.io/en/latest/changes.html), from 2.0 onwards it only supports the legacy binary file formats.
