### PR TITLE
Adding Checkbox support

### DIFF
--- a/dev/docs/source/format.rst
+++ b/dev/docs/source/format.rst
@@ -278,6 +278,8 @@ properties that can be applied and the equivalent object method:
 +------------+------------------+----------------------+------------------------------+
 |            | Right color      | ``'right_color'``    | :func:`set_right_color()`    |
 +------------+------------------+----------------------+------------------------------+
+| Other      | Checkbox         | ``'checkbox'``       | :func:`set_checkbox()`       |
++------------+------------------+----------------------+------------------------------+
 
 The format properties and methods are explained in the following sections.
 
@@ -1211,3 +1213,11 @@ Set the quote prefix property of a format to ensure a string is treated as a
 string after editing. This is the same as prefixing the string with a single
 quote in Excel. You don't need to add the quote to the string but you do need
 to add the format.
+
+
+format.set_checkbox()
+---------------------
+
+.. py:function:: set_checkbox()
+
+Set the checkbox property of a format. This turns the cell into a checkbox.

--- a/examples/checkbox.py
+++ b/examples/checkbox.py
@@ -1,0 +1,33 @@
+##############################################################################
+#
+# A simple example of adding checkboxes to an Excel worksheet with Python
+# and XlsxWriter.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright 2013-2024, John McNamara, jmcnamara@cpan.org
+#
+import xlsxwriter
+
+# Create an new Excel file and add a worksheet.
+workbook = xlsxwriter.Workbook("checkbox.xlsx")
+worksheet = workbook.add_worksheet()
+
+# Widen the first column to make the text clearer.
+worksheet.set_column("A:A", 20)
+
+# Add a checkbox format.
+checkbox = workbook.add_format({"checkbox": True})
+
+# Add a checkbox to A1.
+worksheet.write("A1", "", checkbox)
+
+# Add a checked checkbox to A2.
+worksheet.write("A2", True, checkbox)
+
+# Add a checkbox format, colored red.
+red_checkbox = workbook.add_format({"font_color": "#FF0000", "checkbox": True})
+
+# Add a red checkbox to A3.
+worksheet.write("A3", True, red_checkbox)
+
+workbook.close()

--- a/xlsxwriter/contenttypes.py
+++ b/xlsxwriter/contenttypes.py
@@ -207,6 +207,15 @@ class ContentTypes(xmlwriter.XMLwriter):
             )
         )
 
+    def _add_feature_property_bag(self):
+        # Add the feature property bag to the ContentTypes overrides.
+        self._add_override(
+            (
+                "/xl/featurePropertyBag/featurePropertyBag.xml",
+                "application/vnd.ms-excel.featurepropertybag+xml",
+            )
+        )
+
     ###########################################################################
     #
     # XML methods.

--- a/xlsxwriter/feature_property_bag.py
+++ b/xlsxwriter/feature_property_bag.py
@@ -1,0 +1,119 @@
+###############################################################################
+#
+# FeaturePropertyBag - A class for writing the Excel XLSX FeaturePropertyBag file.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright 2013-2024, John McNamara, jmcnamara@cpan.org
+#
+
+from . import xmlwriter
+
+
+class FeaturePropertyBag(xmlwriter.XMLwriter):
+    """
+    A class for writing the Excel XLSX FeaturePropertyBag file.
+
+
+    """
+
+    ###########################################################################
+    #
+    # Public API.
+    #
+    ###########################################################################
+
+    def __init__(self):
+        """
+        Constructor.
+
+        """
+
+        super().__init__()
+        self.bag_id_count = 0
+        self.checkbox = False
+
+    ###########################################################################
+    #
+    # Private API.
+    #
+    ###########################################################################
+
+    def _assemble_xml_file(self):
+        # Assemble and write the XML file.
+
+        # Write the XML declaration.
+        self._xml_declaration()
+
+        # Write the featurePropertyBag element.
+        self._write_feature_property_bag()
+
+        # Close the file.
+        self._xml_close()
+
+    ###########################################################################
+    #
+    # XML methods.
+    #
+    ###########################################################################
+
+    def _write_feature_property_bag(self):
+        # Write the <FeaturePropertyBags> element.
+
+        xmlns = "http://schemas.microsoft.com/office/spreadsheetml/2022/featurepropertybag"
+
+        attributes = [
+            ('xmlns', xmlns),
+        ]
+
+        self._xml_start_tag('FeaturePropertyBags', attributes)
+
+        # Write the <bag> elements.
+        if self.checkbox:
+            self._write_checkbox()
+
+        self._xml_end_tag('FeaturePropertyBags')
+
+    def _write_checkbox(self):
+        # Write a checkbox element.
+
+        # add Checkbox element
+        attributes1 = [
+            ('type', 'Checkbox'),
+        ]
+        self._xml_empty_tag('bag', attributes1)
+        # add XFControls element
+        attributes2 = [
+            ('type', 'XFControls')
+        ]
+        self._xml_start_tag('bag', attributes2)
+        attributes3 = [
+            ('k', 'CellControl')
+        ]
+        self._xml_data_element('bagId', self.bag_id_count, attributes3)
+        self.bag_id_count += 1
+        self._xml_end_tag('bag')
+        # add XFComplement element
+        attributes4 = [
+            ('type', 'XFComplement')
+        ]
+        self._xml_start_tag('bag', attributes4)
+        attributes5 = [
+            ('k', 'XFControls')
+        ]
+        self._xml_data_element('bagId', self.bag_id_count, attributes5)
+        self.bag_id_count += 1
+        self._xml_end_tag('bag')
+        # add XFComplements element
+        attributes6 = [
+            ('type', 'XFComplements'),
+            ('extRef', 'XFComplementsMapperExtRef')
+        ]
+        self._xml_start_tag('bag', attributes6)
+        attributes7 = [
+            ('k', 'MappedFeaturePropertyBags')
+        ]
+        self._xml_start_tag('a', attributes7)
+        self._xml_data_element('bagId', self.bag_id_count)
+        self.bag_id_count += 1
+        self._xml_end_tag('a')
+        self._xml_end_tag('bag')

--- a/xlsxwriter/feature_property_bag.py
+++ b/xlsxwriter/feature_property_bag.py
@@ -59,7 +59,9 @@ class FeaturePropertyBag(xmlwriter.XMLwriter):
     def _write_feature_property_bag(self):
         # Write the <FeaturePropertyBags> element.
 
-        xmlns = "http://schemas.microsoft.com/office/spreadsheetml/2022/featurepropertybag"
+        xmlns = (
+            "http://schemas.microsoft.com/office/spreadsheetml/2022/featurepropertybag"
+        )
 
         attributes = [
             ('xmlns', xmlns),

--- a/xlsxwriter/feature_property_bag.py
+++ b/xlsxwriter/feature_property_bag.py
@@ -64,58 +64,48 @@ class FeaturePropertyBag(xmlwriter.XMLwriter):
         )
 
         attributes = [
-            ('xmlns', xmlns),
+            ("xmlns", xmlns),
         ]
 
-        self._xml_start_tag('FeaturePropertyBags', attributes)
+        self._xml_start_tag("FeaturePropertyBags", attributes)
 
         # Write the <bag> elements.
         if self.checkbox:
             self._write_checkbox()
 
-        self._xml_end_tag('FeaturePropertyBags')
+        self._xml_end_tag("FeaturePropertyBags")
 
     def _write_checkbox(self):
         # Write a checkbox element.
 
         # add Checkbox element
         attributes1 = [
-            ('type', 'Checkbox'),
+            ("type", "Checkbox"),
         ]
-        self._xml_empty_tag('bag', attributes1)
+        self._xml_empty_tag("bag", attributes1)
         # add XFControls element
-        attributes2 = [
-            ('type', 'XFControls')
-        ]
-        self._xml_start_tag('bag', attributes2)
-        attributes3 = [
-            ('k', 'CellControl')
-        ]
-        self._xml_data_element('bagId', self.bag_id_count, attributes3)
+        attributes2 = [("type", "XFControls")]
+        self._xml_start_tag("bag", attributes2)
+        attributes3 = [("k", "CellControl")]
+        self._xml_data_element("bagId", self.bag_id_count, attributes3)
         self.bag_id_count += 1
-        self._xml_end_tag('bag')
+        self._xml_end_tag("bag")
         # add XFComplement element
-        attributes4 = [
-            ('type', 'XFComplement')
-        ]
-        self._xml_start_tag('bag', attributes4)
-        attributes5 = [
-            ('k', 'XFControls')
-        ]
-        self._xml_data_element('bagId', self.bag_id_count, attributes5)
+        attributes4 = [("type", "XFComplement")]
+        self._xml_start_tag("bag", attributes4)
+        attributes5 = [("k", "XFControls")]
+        self._xml_data_element("bagId", self.bag_id_count, attributes5)
         self.bag_id_count += 1
-        self._xml_end_tag('bag')
+        self._xml_end_tag("bag")
         # add XFComplements element
         attributes6 = [
-            ('type', 'XFComplements'),
-            ('extRef', 'XFComplementsMapperExtRef')
+            ("type", "XFComplements"),
+            ("extRef", "XFComplementsMapperExtRef"),
         ]
-        self._xml_start_tag('bag', attributes6)
-        attributes7 = [
-            ('k', 'MappedFeaturePropertyBags')
-        ]
-        self._xml_start_tag('a', attributes7)
-        self._xml_data_element('bagId', self.bag_id_count)
+        self._xml_start_tag("bag", attributes6)
+        attributes7 = [("k", "MappedFeaturePropertyBags")]
+        self._xml_start_tag("a", attributes7)
+        self._xml_data_element("bagId", self.bag_id_count)
         self.bag_id_count += 1
-        self._xml_end_tag('a')
-        self._xml_end_tag('bag')
+        self._xml_end_tag("a")
+        self._xml_end_tag("bag")

--- a/xlsxwriter/format.py
+++ b/xlsxwriter/format.py
@@ -64,6 +64,7 @@ class Format(xmlwriter.XMLwriter):
         self.theme = 0
         self.hyperlink = False
         self.xf_id = 0
+        self.checkbox = False
 
         self.hidden = 0
         self.locked = 1
@@ -896,6 +897,19 @@ class Format(xmlwriter.XMLwriter):
         self.set_underline(1)
         self.set_theme(10)
         self.hyperlink = hyperlink
+
+    def set_checkbox(self, checkbox=True):
+        """
+        Set the properties for the checkbox style.
+
+        Args:
+            checkbox: Default is True, turns property on.
+
+        Returns:
+            Nothing.
+
+        """
+        self.checkbox = checkbox
 
     def set_color_indexed(self, color_index):
         """

--- a/xlsxwriter/packager.py
+++ b/xlsxwriter/packager.py
@@ -20,6 +20,7 @@ from .contenttypes import ContentTypes
 from .core import Core
 from .custom import Custom
 from .exceptions import EmptyChartSeries
+from .feature_property_bag import FeaturePropertyBag
 from .metadata import Metadata
 from .relationships import Relationships
 from .rich_value import RichValue
@@ -160,6 +161,7 @@ class Packager:
         self._write_app_file()
         self._write_metadata_file()
         self._write_rich_value_files()
+        self._write_feature_property_bag_file()
 
         return self.filenames
 
@@ -409,6 +411,17 @@ class Packager:
         xml_file._set_xml_writer(filename)
         xml_file._assemble_xml_file()
 
+    def _write_feature_property_bag_file(self):
+        # Write the featurePropertyBag.xml file.
+        if not self.workbook.has_feature_property_bag:
+            return
+
+        feature_property_bag = FeaturePropertyBag()
+        feature_property_bag.checkbox = self.workbook.has_checkbox
+
+        feature_property_bag._set_xml_writer(self._filename("xl/featurePropertyBag/featurePropertyBag.xml"))
+        feature_property_bag._assemble_xml_file()
+
     def _write_custom_file(self):
         # Write the custom.xml file.
         properties = self.workbook.custom_properties
@@ -474,6 +487,9 @@ class Packager:
         # Add the RichValue file if present.
         if self.workbook.embedded_images.has_images():
             content._add_rich_value()
+
+        if self.workbook.has_feature_property_bag:
+            content._add_feature_property_bag()
 
         content._set_xml_writer(self._filename("[Content_Types].xml"))
         content._assemble_xml_file()
@@ -593,6 +609,9 @@ class Packager:
         # Add the RichValue files if present.
         if self.workbook.embedded_images.has_images():
             rels._add_rich_value_relationship()
+
+        if self.workbook.has_feature_property_bag:
+            rels._add_feature_property_bag_relationship()
 
         rels._set_xml_writer(self._filename("xl/_rels/workbook.xml.rels"))
         rels._assemble_xml_file()

--- a/xlsxwriter/packager.py
+++ b/xlsxwriter/packager.py
@@ -419,7 +419,8 @@ class Packager:
         feature_property_bag = FeaturePropertyBag()
         feature_property_bag.checkbox = self.workbook.has_checkbox
 
-        feature_property_bag._set_xml_writer(self._filename("xl/featurePropertyBag/featurePropertyBag.xml"))
+        filename = self._filename("xl/featurePropertyBag/featurePropertyBag.xml")
+        feature_property_bag._set_xml_writer(filename)
         feature_property_bag._assemble_xml_file()
 
     def _write_custom_file(self):

--- a/xlsxwriter/relationships.py
+++ b/xlsxwriter/relationships.py
@@ -97,6 +97,13 @@ class Relationships(xmlwriter.XMLwriter):
         target = "richData/rdRichValueTypes.xml"
         self.relationships.append((rel_type, target, None))
 
+    def _add_feature_property_bag_relationship(self):
+        # Add FeaturePropertyBag relationship to XLSX .rels xml files.
+        schema = "http://schemas.microsoft.com/office/2022/11/relationships/"
+        rel_type = schema + "FeaturePropertyBag"
+        target = "featurePropertyBag/featurePropertyBag.xml"
+        self.relationships.append((rel_type, target, None))
+
     ###########################################################################
     #
     # XML methods.

--- a/xlsxwriter/styles.py
+++ b/xlsxwriter/styles.py
@@ -636,6 +636,25 @@ class Styles(xmlwriter.XMLwriter):
         else:
             self._xml_empty_tag("xf", attributes)
 
+    def _write_ext_lst_checkbox(self):
+        # Write the <extLst> element for the checkbox.
+
+        uri = "{C7286773-470A-42A8-94C5-96B5CB345126}"
+        xmlns_xfpb = "http://schemas.microsoft.com/office/spreadsheetml/2022/featurepropertybag"
+
+        attributes1 = [
+            ("uri", uri),
+            ("xmlns:xfpb", xmlns_xfpb),
+        ]
+
+        attributes2 = [("i", 0)]
+
+        self._xml_start_tag("extLst")
+        self._xml_start_tag("ext", attributes1)
+        self._xml_empty_tag("xfpb:xfComplement", attributes=attributes2)
+        self._xml_end_tag("ext")
+        self._xml_end_tag("extLst")
+
     def _write_cell_styles(self):
         # Write the <cellStyles> element.
         count = 1

--- a/xlsxwriter/styles.py
+++ b/xlsxwriter/styles.py
@@ -626,12 +626,14 @@ class Styles(xmlwriter.XMLwriter):
                 has_protect = 1
 
         # Write XF with sub-elements if required.
-        if has_align or has_protect:
+        if has_align or has_protect or xf_format.checkbox:
             self._xml_start_tag("xf", attributes)
             if has_align:
                 self._xml_empty_tag("alignment", align)
             if has_protect:
                 self._xml_empty_tag("protection", protection)
+            if xf_format.checkbox:
+                self._write_ext_lst_checkbox()
             self._xml_end_tag("xf")
         else:
             self._xml_empty_tag("xf", attributes)

--- a/xlsxwriter/styles.py
+++ b/xlsxwriter/styles.py
@@ -642,7 +642,9 @@ class Styles(xmlwriter.XMLwriter):
         # Write the <extLst> element for the checkbox.
 
         uri = "{C7286773-470A-42A8-94C5-96B5CB345126}"
-        xmlns_xfpb = "http://schemas.microsoft.com/office/spreadsheetml/2022/featurepropertybag"
+        xmlns_xfpb = (
+            "http://schemas.microsoft.com/office/spreadsheetml/2022/featurepropertybag"
+        )
 
         attributes1 = [
             ("uri", uri),

--- a/xlsxwriter/test/contenttypes/test_contenttypes02.py
+++ b/xlsxwriter/test/contenttypes/test_contenttypes02.py
@@ -1,0 +1,62 @@
+###############################################################################
+#
+# Tests for XlsxWriter.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright (c), 2013-2024, John McNamara, jmcnamara@cpan.org
+#
+
+import unittest
+from io import StringIO
+
+from ...contenttypes import ContentTypes
+from ..helperfunctions import _xml_to_list
+
+
+class TestAssembleContentTypes(unittest.TestCase):
+    """
+    Test assembling a complete ContentTypes file.
+
+    """
+
+    def test_assemble_xml_file(self):
+        """Test writing an ContentTypes file."""
+        self.maxDiff = None
+
+        fh = StringIO()
+        content = ContentTypes()
+        content._set_filehandle(fh)
+
+        content._add_worksheet_name("sheet1")
+        content._add_default(("jpeg", "image/jpeg"))
+        content._add_shared_strings()
+        content._add_calc_chain()
+        content._add_feature_property_bag()
+
+        content._assemble_xml_file()
+
+        exp = _xml_to_list(
+            """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+
+                  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+                  <Default Extension="xml" ContentType="application/xml"/>
+                  <Default Extension="jpeg" ContentType="image/jpeg"/>
+
+                  <Override PartName="/docProps/app.xml" ContentType="application/vnd.openxmlformats-officedocument.extended-properties+xml"/>
+                  <Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>
+                  <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
+                  <Override PartName="/xl/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>
+                  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+                  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+                  <Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
+                  <Override PartName="/xl/calcChain.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.calcChain+xml"/>
+                  <Override PartName="/xl/featurePropertyBag/featurePropertyBag.xml" ContentType="application/vnd.ms-excel.featurepropertybag+xml"/>
+                </Types>
+                """
+        )
+
+        got = _xml_to_list(fh.getvalue())
+
+        self.assertEqual(got, exp)

--- a/xlsxwriter/test/feature_property_bag/test_feature_property_bag01.py
+++ b/xlsxwriter/test/feature_property_bag/test_feature_property_bag01.py
@@ -1,0 +1,56 @@
+###############################################################################
+#
+# Tests for XlsxWriter.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright (c), 2013-2024, John McNamara, jmcnamara@cpan.org
+#
+
+import unittest
+from io import StringIO
+
+from ...feature_property_bag import FeaturePropertyBag
+from ..helperfunctions import _xml_to_list
+
+
+class TestAssembleFeaturePropertyBag(unittest.TestCase):
+    """
+    Test assembling a complete FeaturePropertyBag file.
+
+    """
+
+    def test_assemble_xml_file(self):
+        """Test for checkbox only."""
+        self.maxDiff = None
+
+        fh = StringIO()
+        feature_property_bag = FeaturePropertyBag()
+        feature_property_bag._set_filehandle(fh)
+
+        feature_property_bag.checkbox = True
+
+        feature_property_bag._assemble_xml_file()
+
+        exp = _xml_to_list(
+            """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <FeaturePropertyBags xmlns="http://schemas.microsoft.com/office/spreadsheetml/2022/featurepropertybag">
+                    <bag type="Checkbox"/>
+                    <bag type="XFControls">
+                        <bagId k="CellControl">0</bagId>
+                    </bag>
+                    <bag type="XFComplement">
+                        <bagId k="XFControls">1</bagId>
+                    </bag>
+                    <bag type="XFComplements" extRef="XFComplementsMapperExtRef">
+                        <a k="MappedFeaturePropertyBags">
+                            <bagId>2</bagId>
+                        </a>
+                    </bag>
+                </FeaturePropertyBags>
+                """
+        )
+
+        got = _xml_to_list(fh.getvalue())
+
+        self.assertEqual(got, exp)

--- a/xlsxwriter/test/relationships/test_relationships02.py
+++ b/xlsxwriter/test/relationships/test_relationships02.py
@@ -1,0 +1,55 @@
+###############################################################################
+#
+# Tests for XlsxWriter.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright (c), 2013-2024, John McNamara, jmcnamara@cpan.org
+#
+
+import unittest
+from io import StringIO
+
+from ...relationships import Relationships
+from ..helperfunctions import _xml_to_list
+
+
+class TestAssembleRelationships(unittest.TestCase):
+    """
+    Test assembling a complete Relationships file.
+
+    """
+
+    def test_assemble_xml_file(self):
+        """Test writing an Relationships file."""
+        self.maxDiff = None
+
+        fh = StringIO()
+        rels = Relationships()
+        rels._set_filehandle(fh)
+
+        rels._add_document_relationship("/worksheet", "worksheets/sheet1.xml")
+        rels._add_document_relationship("/theme", "theme/theme1.xml")
+        rels._add_document_relationship("/styles", "styles.xml")
+        rels._add_document_relationship("/sharedStrings", "sharedStrings.xml")
+        rels._add_document_relationship("/calcChain", "calcChain.xml")
+        rels._add_feature_property_bag_relationship()
+
+        rels._assemble_xml_file()
+
+        exp = _xml_to_list(
+            """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+                  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+                  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="theme/theme1.xml"/>
+                  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+                  <Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>
+                  <Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/calcChain" Target="calcChain.xml"/>
+                  <Relationship Id="rId6" Type="http://schemas.microsoft.com/office/2022/11/relationships/FeaturePropertyBag" Target="featurePropertyBag/featurePropertyBag.xml"/>
+                </Relationships>
+                """
+        )
+
+        got = _xml_to_list(fh.getvalue())
+
+        self.assertEqual(got, exp)

--- a/xlsxwriter/test/styles/test_styles10.py
+++ b/xlsxwriter/test/styles/test_styles10.py
@@ -1,0 +1,140 @@
+###############################################################################
+#
+# Tests for XlsxWriter.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright (c), 2013-2024, John McNamara, jmcnamara@cpan.org
+#
+
+import unittest
+from io import StringIO
+
+from ...styles import Styles
+from ...workbook import Workbook
+from ..helperfunctions import _xml_to_list
+
+
+class TestAssembleStyles(unittest.TestCase):
+    """
+    Test assembling a complete Styles file.
+
+    """
+
+    def test_assemble_xml_file(self):
+        """Test for simple font styles."""
+        self.maxDiff = None
+
+        fh = StringIO()
+        style = Styles()
+        style._set_filehandle(fh)
+
+        workbook = Workbook()
+
+        workbook.add_format({"bold": 1})
+        workbook.add_format({"italic": 1})
+        workbook.add_format({"bold": 1, "italic": 1})
+        workbook.add_format({"checkbox": True})
+
+        workbook._set_default_xf_indices()
+        workbook._prepare_format_properties()
+
+        style._set_style_properties(
+            [
+                workbook.xf_formats,
+                workbook.palette,
+                workbook.font_count,
+                workbook.num_formats,
+                workbook.border_count,
+                workbook.fill_count,
+                workbook.custom_colors,
+                workbook.dxf_formats,
+                workbook.has_comments,
+            ]
+        )
+
+        style._assemble_xml_file()
+        workbook.fileclosed = 1
+
+        exp = _xml_to_list(
+            """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                  <fonts count="4">
+                    <font>
+                      <sz val="11"/>
+                      <color theme="1"/>
+                      <name val="Calibri"/>
+                      <family val="2"/>
+                      <scheme val="minor"/>
+                    </font>
+                    <font>
+                      <b/>
+                      <sz val="11"/>
+                      <color theme="1"/>
+                      <name val="Calibri"/>
+                      <family val="2"/>
+                      <scheme val="minor"/>
+                    </font>
+                    <font>
+                      <i/>
+                      <sz val="11"/>
+                      <color theme="1"/>
+                      <name val="Calibri"/>
+                      <family val="2"/>
+                      <scheme val="minor"/>
+                    </font>
+                    <font>
+                      <b/>
+                      <i/>
+                      <sz val="11"/>
+                      <color theme="1"/>
+                      <name val="Calibri"/>
+                      <family val="2"/>
+                      <scheme val="minor"/>
+                    </font>
+                  </fonts>
+                  <fills count="2">
+                    <fill>
+                      <patternFill patternType="none"/>
+                    </fill>
+                    <fill>
+                      <patternFill patternType="gray125"/>
+                    </fill>
+                  </fills>
+                  <borders count="1">
+                    <border>
+                      <left/>
+                      <right/>
+                      <top/>
+                      <bottom/>
+                      <diagonal/>
+                    </border>
+                  </borders>
+                  <cellStyleXfs count="1">
+                    <xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>
+                  </cellStyleXfs>
+                  <cellXfs count="5">
+                    <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>
+                    <xf numFmtId="0" fontId="1" fillId="0" borderId="0" xfId="0" applyFont="1"/>
+                    <xf numFmtId="0" fontId="2" fillId="0" borderId="0" xfId="0" applyFont="1"/>
+                    <xf numFmtId="0" fontId="3" fillId="0" borderId="0" xfId="0" applyFont="1"/>
+                    <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0">
+                      <extLst>
+                          <ext uri="{C7286773-470A-42A8-94C5-96B5CB345126}" xmlns:xfpb="http://schemas.microsoft.com/office/spreadsheetml/2022/featurepropertybag">
+                              <xfpb:xfComplement i="0"/>
+                          </ext>
+                      </extLst>
+                  </xf>
+                  </cellXfs>
+                  <cellStyles count="1">
+                    <cellStyle name="Normal" xfId="0" builtinId="0"/>
+                  </cellStyles>
+                  <dxfs count="0"/>
+                  <tableStyles count="0" defaultTableStyle="TableStyleMedium9" defaultPivotStyle="PivotStyleLight16"/>
+                </styleSheet>
+                """
+        )
+
+        got = _xml_to_list(fh.getvalue())
+
+        self.assertEqual(got, exp)

--- a/xlsxwriter/test/styles/test_write_ext_list_checkbox.py
+++ b/xlsxwriter/test/styles/test_write_ext_list_checkbox.py
@@ -1,0 +1,43 @@
+###############################################################################
+#
+# Tests for XlsxWriter.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright (c), 2013-2024, John McNamara, jmcnamara@cpan.org
+#
+
+import unittest
+from io import StringIO
+
+from ...styles import Styles
+from ..helperfunctions import _xml_to_list
+
+
+class TestWriteExtLstCheckbox(unittest.TestCase):
+    """
+    Test the Styles _write_ext_lst_checkbox() method.
+
+    """
+
+    def setUp(self):
+        self.fh = StringIO()
+        self.styles = Styles()
+        self.styles._set_filehandle(self.fh)
+
+    def test_write_ext_lst_checkbox(self):
+        """Test the _write_ext_lst_checkbox() method"""
+
+        self.styles._write_ext_lst_checkbox()
+
+        exp = _xml_to_list(
+            """
+                <extLst>
+                    <ext uri="{C7286773-470A-42A8-94C5-96B5CB345126}" xmlns:xfpb="http://schemas.microsoft.com/office/spreadsheetml/2022/featurepropertybag">
+                        <xfpb:xfComplement i="0"/>
+                    </ext>
+                </extLst>
+            """
+        )
+        got = _xml_to_list(self.fh.getvalue())
+
+        self.assertEqual(got, exp)

--- a/xlsxwriter/workbook.py
+++ b/xlsxwriter/workbook.py
@@ -146,6 +146,8 @@ class Workbook(xmlwriter.XMLwriter):
         self.has_embedded_images = False
         self.has_dynamic_functions = False
         self.has_embedded_descriptions = False
+        self.has_checkbox = False
+        self.has_feature_property_bag = False
         self.embedded_images = EmbeddedImages()
 
         # We can't do 'constant_memory' mode while doing 'in_memory' mode.
@@ -750,6 +752,9 @@ class Workbook(xmlwriter.XMLwriter):
 
         # Prepare the metadata file links.
         self._prepare_metadata()
+
+        # Prepare the feature property bag links.
+        self._prepare_feature_property_bag()
 
         # Package the workbook.
         packager._add_workbook(self)
@@ -1500,6 +1505,14 @@ class Workbook(xmlwriter.XMLwriter):
             if sheet.has_dynamic_arrays:
                 self.has_metadata = True
                 self.has_dynamic_functions = True
+
+    def _prepare_feature_property_bag(self):
+        # Set the feature property bag rel link.
+        self.has_checkbox = any(format.checkbox for format in self.formats)
+
+        # currently only used for checkboxes, but could be extended in the future.
+        feature_property_bag_elements = [self.has_checkbox]
+        self.has_feature_property_bag = any(feature_property_bag_elements)
 
     def _add_chart_data(self):
         # Add "cached" data to charts to provide the numCache and strCache


### PR DESCRIPTION
## 📑 Description

Added in the ability to format cells as checkboxes, closing #1092.

Steps taken:
- explored the xml changes produced by Excel, comparing the below:
  - blank Excel.
  - Excel with a single checkbox.
  - Excel with two checkboxes; one unchecked, one checked.
  - Excel with two checkboxes and one normal text.
- updated the package components as required, testing to ensure the expected functionality.
  - it turns out that a checkbox is a special type of style component, in a `featurePropertyBag.xml` file. I did not explore further to see if any other useful components would also be in the file, but aimed to keep the code flexible for any such components being added in the future.
- created an example, which ran without issue.
- updated `format` docs.

## 🧪 Testing

- added tests, building upon existing.
- created and ran example program.

## ✅ Checks
- [x] I have sanity checked my change
- [x] All the tests and pre-commit hooks have passed
- [x] Lint

## ℹ Additional Information

This work is required for a project I'm working on. I can extend the functionality of `XlsxWriter` locally; however, I thought it would be best to share.

Let me know if any tweaks are needed (I tried to copy the existing style as much as possible, including the lack of typing!).

I wasn't sure if you wanted this squashed or not. Just let me know.
