### PR TITLE
Add py.typed and Dict[str, Any] to all 'options' parameters

### DIFF
--- a/xlsxwriter/chart.py
+++ b/xlsxwriter/chart.py
@@ -9,7 +9,7 @@
 
 import copy
 import re
-from typing import Optional
+from typing import Any, Dict, Optional
 from warnings import warn
 
 from xlsxwriter.color import Color, ColorTypes
@@ -113,7 +113,7 @@ class Chart(xmlwriter.XMLwriter):
         self._set_default_properties()
         self.fill = {}
 
-    def add_series(self, options=None) -> None:
+    def add_series(self, options: Optional[Dict[str, Any]] = None) -> None:
         """
         Add a data series to a chart.
 
@@ -260,7 +260,7 @@ class Chart(xmlwriter.XMLwriter):
 
         self.series.append(series)
 
-    def set_x_axis(self, options) -> None:
+    def set_x_axis(self, options: Dict[str, Any]) -> None:
         """
         Set the chart X axis options.
 
@@ -275,7 +275,7 @@ class Chart(xmlwriter.XMLwriter):
 
         self.x_axis = axis
 
-    def set_y_axis(self, options) -> None:
+    def set_y_axis(self, options: Dict[str, Any]) -> None:
         """
         Set the chart Y axis options.
 
@@ -290,7 +290,7 @@ class Chart(xmlwriter.XMLwriter):
 
         self.y_axis = axis
 
-    def set_x2_axis(self, options) -> None:
+    def set_x2_axis(self, options: Dict[str, Any]) -> None:
         """
         Set the chart secondary X axis options.
 
@@ -305,7 +305,7 @@ class Chart(xmlwriter.XMLwriter):
 
         self.x2_axis = axis
 
-    def set_y2_axis(self, options) -> None:
+    def set_y2_axis(self, options: Dict[str, Any]) -> None:
         """
         Set the chart secondary Y axis options.
 
@@ -320,7 +320,7 @@ class Chart(xmlwriter.XMLwriter):
 
         self.y2_axis = axis
 
-    def set_title(self, options=None) -> None:
+    def set_title(self, options: Optional[Dict[str, Any]] = None) -> None:
         """
         Set the chart title options.
 
@@ -355,7 +355,7 @@ class Chart(xmlwriter.XMLwriter):
         # Set the automatic title option.
         self.title_none = options.get("none")
 
-    def set_legend(self, options) -> None:
+    def set_legend(self, options: Dict[str, Any]) -> None:
         """
         Set the chart legend options.
 
@@ -368,7 +368,7 @@ class Chart(xmlwriter.XMLwriter):
         # Convert the user defined properties to internal properties.
         self.legend = self._get_legend_properties(options)
 
-    def set_plotarea(self, options) -> None:
+    def set_plotarea(self, options: Dict[str, Any]) -> None:
         """
         Set the chart plot area options.
 
@@ -381,7 +381,7 @@ class Chart(xmlwriter.XMLwriter):
         # Convert the user defined properties to internal properties.
         self.plotarea = self._get_area_properties(options)
 
-    def set_chartarea(self, options) -> None:
+    def set_chartarea(self, options: Dict[str, Any]) -> None:
         """
         Set the chart area options.
 
@@ -462,7 +462,7 @@ class Chart(xmlwriter.XMLwriter):
         """
         self.show_hidden = True
 
-    def set_size(self, options=None) -> None:
+    def set_size(self, options: Optional[Dict[str, Any]] = None) -> None:
         """
         Set size or scale of the chart.
 
@@ -483,7 +483,7 @@ class Chart(xmlwriter.XMLwriter):
         self.x_offset = options.get("x_offset", 0)
         self.y_offset = options.get("y_offset", 0)
 
-    def set_table(self, options=None) -> None:
+    def set_table(self, options: Optional[Dict[str, Any]] = None) -> None:
         """
         Set properties for an axis data table.
 
@@ -507,7 +507,7 @@ class Chart(xmlwriter.XMLwriter):
 
         self.table = table
 
-    def set_up_down_bars(self, options=None) -> None:
+    def set_up_down_bars(self, options: Optional[Dict[str, Any]] = None) -> None:
         """
         Set properties for the chart up-down bars.
 
@@ -562,7 +562,7 @@ class Chart(xmlwriter.XMLwriter):
             },
         }
 
-    def set_drop_lines(self, options=None) -> None:
+    def set_drop_lines(self, options: Optional[Dict[str, Any]] = None) -> None:
         """
         Set properties for the chart drop lines.
 
@@ -601,7 +601,7 @@ class Chart(xmlwriter.XMLwriter):
             "gradient": gradient,
         }
 
-    def set_high_low_lines(self, options=None) -> None:
+    def set_high_low_lines(self, options: Optional[Dict[str, Any]] = None) -> None:
         """
         Set properties for the chart high-low lines.
 
@@ -1368,7 +1368,7 @@ class Chart(xmlwriter.XMLwriter):
 
         return area
 
-    def _get_legend_properties(self, options=None):
+    def _get_legend_properties(self, options: Optional[Dict[str, Any]] = None):
         # Convert user legend properties to the structure required internally.
         legend = {}
 

--- a/xlsxwriter/chart_area.py
+++ b/xlsxwriter/chart_area.py
@@ -7,6 +7,8 @@
 # Copyright (c) 2013-2025, John McNamara, jmcnamara@cpan.org
 #
 
+from typing import Any, Dict, Optional
+
 from . import chart
 
 
@@ -23,7 +25,7 @@ class ChartArea(chart.Chart):
     #
     ###########################################################################
 
-    def __init__(self, options=None) -> None:
+    def __init__(self, options: Optional[Dict[str, Any]] = None) -> None:
         """
         Constructor.
 

--- a/xlsxwriter/chart_bar.py
+++ b/xlsxwriter/chart_bar.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2013-2025, John McNamara, jmcnamara@cpan.org
 #
 
-from typing import Optional
+from typing import Any, Dict, Optional
 from warnings import warn
 
 from . import chart
@@ -26,7 +26,7 @@ class ChartBar(chart.Chart):
     #
     ###########################################################################
 
-    def __init__(self, options=None) -> None:
+    def __init__(self, options: Optional[Dict[str, Any]] = None) -> None:
         """
         Constructor.
 

--- a/xlsxwriter/chart_column.py
+++ b/xlsxwriter/chart_column.py
@@ -7,6 +7,8 @@
 # Copyright (c) 2013-2025, John McNamara, jmcnamara@cpan.org
 #
 
+from typing import Any, Dict, Optional
+
 from . import chart
 
 
@@ -23,7 +25,7 @@ class ChartColumn(chart.Chart):
     #
     ###########################################################################
 
-    def __init__(self, options=None) -> None:
+    def __init__(self, options: Optional[Dict[str, Any]] = None) -> None:
         """
         Constructor.
 

--- a/xlsxwriter/chart_line.py
+++ b/xlsxwriter/chart_line.py
@@ -7,6 +7,8 @@
 # Copyright (c) 2013-2025, John McNamara, jmcnamara@cpan.org
 #
 
+from typing import Any, Dict, Optional
+
 from . import chart
 
 
@@ -23,7 +25,7 @@ class ChartLine(chart.Chart):
     #
     ###########################################################################
 
-    def __init__(self, options=None) -> None:
+    def __init__(self, options: Optional[Dict[str, Any]] = None) -> None:
         """
         Constructor.
 

--- a/xlsxwriter/chart_radar.py
+++ b/xlsxwriter/chart_radar.py
@@ -7,6 +7,8 @@
 # Copyright (c) 2013-2025, John McNamara, jmcnamara@cpan.org
 #
 
+from typing import Any, Dict, Optional
+
 from . import chart
 
 
@@ -23,7 +25,7 @@ class ChartRadar(chart.Chart):
     #
     ###########################################################################
 
-    def __init__(self, options=None) -> None:
+    def __init__(self, options: Optional[Dict[str, Any]] = None) -> None:
         """
         Constructor.
 

--- a/xlsxwriter/chart_scatter.py
+++ b/xlsxwriter/chart_scatter.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2013-2025, John McNamara, jmcnamara@cpan.org
 #
 
-from typing import Optional
+from typing import Any, Dict, Optional
 from warnings import warn
 
 from . import chart
@@ -26,7 +26,7 @@ class ChartScatter(chart.Chart):
     #
     ###########################################################################
 
-    def __init__(self, options=None) -> None:
+    def __init__(self, options: Optional[Dict[str, Any]] = None) -> None:
         """
         Constructor.
 

--- a/xlsxwriter/chartsheet.py
+++ b/xlsxwriter/chartsheet.py
@@ -7,6 +7,8 @@
 # Copyright (c) 2013-2025, John McNamara, jmcnamara@cpan.org
 #
 
+from typing import Any, Dict, Optional
+
 from xlsxwriter.chart import Chart
 
 from . import worksheet
@@ -56,7 +58,9 @@ class Chartsheet(worksheet.Worksheet):
         self.charts.append([0, 0, chart, 0, 0, 1, 1])
         return chart
 
-    def protect(self, password: str = "", options=None) -> None:
+    def protect(
+        self, password: str = "", options: Optional[Dict[str, Any]] = None
+    ) -> None:
         """
         Set the password and protection options of the worksheet.
 

--- a/xlsxwriter/py.typed
+++ b/xlsxwriter/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/xlsxwriter/url.py
+++ b/xlsxwriter/url.py
@@ -10,7 +10,7 @@
 
 import re
 from enum import Enum
-from typing import Optional
+from typing import Any, Dict, Optional
 
 
 class UrlTypes(Enum):
@@ -77,7 +77,7 @@ class Url:
         )
 
     @classmethod
-    def from_options(cls, options: dict) -> Optional["Url"]:
+    def from_options(cls, options: Dict[str, Any]) -> Optional["Url"]:
         """
         For backward compatibility, convert the 'url' key and 'tip' keys in an
         options dictionary to a Url object, or return the Url object if already

--- a/xlsxwriter/workbook.py
+++ b/xlsxwriter/workbook.py
@@ -15,7 +15,7 @@ import time
 from datetime import datetime, timezone
 from decimal import Decimal
 from fractions import Fraction
-from typing import Any, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from warnings import warn
 from zipfile import ZIP_DEFLATED, LargeZipFile, ZipFile, ZipInfo
 
@@ -61,7 +61,9 @@ class Workbook(xmlwriter.XMLwriter):
     chartsheet_class = Chartsheet
     worksheet_class = Worksheet
 
-    def __init__(self, filename: Optional[str] = None, options=None) -> None:
+    def __init__(
+        self, filename: Optional[str] = None, options: Optional[Dict[str, Any]] = None
+    ) -> None:
         """
         Constructor.
 
@@ -245,7 +247,7 @@ class Workbook(xmlwriter.XMLwriter):
 
         return xf_format
 
-    def add_chart(self, options) -> Optional[
+    def add_chart(self, options: Dict[str, Any]) -> Optional[
         Union[
             ChartArea,
             ChartBar,

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -21,7 +21,7 @@ from fractions import Fraction
 from functools import wraps
 from io import BytesIO, StringIO
 from math import isinf, isnan
-from typing import Any, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from warnings import warn
 
 from xlsxwriter.chart import Chart
@@ -1555,7 +1555,11 @@ class Worksheet(xmlwriter.XMLwriter):
 
     @convert_cell_args
     def insert_image(
-        self, row: int, col: int, source: Union[str, BytesIO, Image], options=None
+        self,
+        row: int,
+        col: int,
+        source: Union[str, BytesIO, Image],
+        options: Optional[Dict[str, Any]] = None,
     ) -> Literal[0, -1]:
         """
         Insert an image with its top-left corner in a worksheet cell.
@@ -1589,7 +1593,11 @@ class Worksheet(xmlwriter.XMLwriter):
 
     @convert_cell_args
     def embed_image(
-        self, row: int, col: int, source: Union[str, BytesIO, Image], options=None
+        self,
+        row: int,
+        col: int,
+        source: Union[str, BytesIO, Image],
+        options: Optional[Dict[str, Any]] = None,
     ) -> Literal[0, -1]:
         """
         Embed an image in a worksheet cell.
@@ -1636,7 +1644,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
     @convert_cell_args
     def insert_textbox(
-        self, row: int, col: int, text: str, options=None
+        self, row: int, col: int, text: str, options: Optional[Dict[str, Any]] = None
     ) -> Literal[0, -1]:
         """
         Insert an textbox with its top-left corner in a worksheet cell.
@@ -1690,7 +1698,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
     @convert_cell_args
     def insert_chart(
-        self, row: int, col: int, chart: Chart, options=None
+        self, row: int, col: int, chart: Chart, options: Optional[Dict[str, Any]] = None
     ) -> Literal[0, -1, -2]:
         """
         Insert an chart with its top-left corner in a worksheet cell.
@@ -1763,7 +1771,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
     @convert_cell_args
     def write_comment(
-        self, row: int, col: int, comment: str, options=None
+        self, row: int, col: int, comment: str, options: Optional[Dict[str, Any]] = None
     ) -> Literal[0, -1, -2]:
         """
         Write a comment to a worksheet cell.
@@ -1956,7 +1964,7 @@ class Worksheet(xmlwriter.XMLwriter):
         last_col: int,
         width: Optional[float] = None,
         cell_format: Optional[Format] = None,
-        options=None,
+        options: Optional[Dict[str, Any]] = None,
     ) -> Literal[0, -1]:
         """
         Set the width, and other properties of a single column or a
@@ -2023,7 +2031,7 @@ class Worksheet(xmlwriter.XMLwriter):
         last_col: int,
         width: Optional[float] = None,
         cell_format: Optional[Format] = None,
-        options=None,
+        options: Optional[Dict[str, Any]] = None,
     ) -> Literal[0, -1]:
         """
         Set the width, and other properties of a single column or a
@@ -2200,7 +2208,7 @@ class Worksheet(xmlwriter.XMLwriter):
         row: int,
         height: Optional[float] = None,
         cell_format: Optional[Format] = None,
-        options=None,
+        options: Optional[Dict[str, Any]] = None,
     ) -> Literal[0, -1]:
         """
         Set the width, and other properties of a row.
@@ -2264,7 +2272,7 @@ class Worksheet(xmlwriter.XMLwriter):
         row: int,
         height: Optional[float] = None,
         cell_format: Optional[Format] = None,
-        options=None,
+        options: Optional[Dict[str, Any]] = None,
     ) -> Literal[0, -1]:
         """
         Set the width (in pixels), and other properties of a row.
@@ -2541,7 +2549,12 @@ class Worksheet(xmlwriter.XMLwriter):
 
     @convert_range_args
     def data_validation(
-        self, first_row: int, first_col: int, last_row: int, last_col: int, options=None
+        self,
+        first_row: int,
+        first_col: int,
+        last_row: int,
+        last_col: int,
+        options: Optional[Dict[str, Any]] = None,
     ) -> Literal[0, -1, -2]:
         """
         Add a data validation to a worksheet.
@@ -2802,7 +2815,12 @@ class Worksheet(xmlwriter.XMLwriter):
 
     @convert_range_args
     def conditional_format(
-        self, first_row: int, first_col: int, last_row: int, last_col: int, options=None
+        self,
+        first_row: int,
+        first_col: int,
+        last_row: int,
+        last_col: int,
+        options: Optional[Dict[str, Any]] = None,
     ) -> Literal[0, -1, -2]:
         """
         Add a conditional format to a worksheet.
@@ -3307,7 +3325,12 @@ class Worksheet(xmlwriter.XMLwriter):
 
     @convert_range_args
     def add_table(
-        self, first_row: int, first_col: int, last_row: int, last_col: int, options=None
+        self,
+        first_row: int,
+        first_col: int,
+        last_row: int,
+        last_col: int,
+        options: Optional[Dict[str, Any]] = None,
     ) -> Literal[0, -1, -2, -3]:
         """
         Add an Excel table to a worksheet.
@@ -3650,7 +3673,9 @@ class Worksheet(xmlwriter.XMLwriter):
         return 0
 
     @convert_cell_args
-    def add_sparkline(self, row: int, col: int, options=None) -> Literal[0, -1, -2]:
+    def add_sparkline(
+        self, row: int, col: int, options: Optional[Dict[str, Any]] = None
+    ) -> Literal[0, -1, -2]:
         """
         Add sparklines to the worksheet.
 
@@ -4035,7 +4060,9 @@ class Worksheet(xmlwriter.XMLwriter):
         """
         self.tab_color = Color._from_value(color)
 
-    def protect(self, password: str = "", options=None) -> None:
+    def protect(
+        self, password: str = "", options: Optional[Dict[str, Any]] = None
+    ) -> None:
         """
         Set the password and protection options of the worksheet.
 
@@ -4126,7 +4153,9 @@ class Worksheet(xmlwriter.XMLwriter):
         return 0
 
     @convert_cell_args
-    def insert_button(self, row: int, col: int, options=None) -> Literal[0, -1]:
+    def insert_button(
+        self, row: int, col: int, options: Optional[Dict[str, Any]] = None
+    ) -> Literal[0, -1]:
         """
         Insert a button form object into the worksheet.
 
@@ -4323,7 +4352,9 @@ class Worksheet(xmlwriter.XMLwriter):
         self.margin_top = top
         self.margin_bottom = bottom
 
-    def set_header(self, header: str = "", options=None, margin=None) -> None:
+    def set_header(
+        self, header: str = "", options: Optional[Dict[str, Any]] = None, margin=None
+    ) -> None:
         """
         Set the page header caption and optional margin.
 
@@ -4402,7 +4433,9 @@ class Worksheet(xmlwriter.XMLwriter):
         if image_count:
             self.has_header_vml = True
 
-    def set_footer(self, footer: str = "", options=None, margin=None) -> None:
+    def set_footer(
+        self, footer: str = "", options: Optional[Dict[str, Any]] = None, margin=None
+    ) -> None:
         """
         Set the page footer caption and optional margin.
 
@@ -4744,7 +4777,7 @@ class Worksheet(xmlwriter.XMLwriter):
         else:
             self.vba_codename = "Sheet" + str(self.index + 1)
 
-    def ignore_errors(self, options=None) -> Literal[0, -1]:
+    def ignore_errors(self, options: Optional[Dict[str, Any]] = None) -> Literal[0, -1]:
         """
         Ignore various Excel errors/warnings in a worksheet for user defined
         ranges.
@@ -5208,7 +5241,7 @@ class Worksheet(xmlwriter.XMLwriter):
 
         return f"{digest:X}"
 
-    def _image_from_source(self, source, options=None):
+    def _image_from_source(self, source, options: Optional[Dict[str, Any]] = None):
         # Backward compatibility utility method to convert an input argument to
         # an Image object. The source can be a filename, BytesIO stream or
         # an existing Image object.


### PR DESCRIPTION
Part of #1123 

Adds `py.typed` file and all `options` parameters were annotated as `Dict[str, Any]`

In the next PR I could make them TypedDict