### PR TITLE
Add more supported types to filename

### DIFF
--- a/xlsxwriter/workbook.py
+++ b/xlsxwriter/workbook.py
@@ -63,7 +63,7 @@ class Workbook(xmlwriter.XMLwriter):
 
     def __init__(
         self,
-        filename: Optional[str | IO[AnyStr] | os.PathLike] = None,
+        filename: Optional[Union[str, IO[AnyStr], os.PathLike]] = None,
         options: Optional[Dict[str, Any]] = None,
     ) -> None:
         """

--- a/xlsxwriter/workbook.py
+++ b/xlsxwriter/workbook.py
@@ -15,7 +15,7 @@ import time
 from datetime import datetime, timezone
 from decimal import Decimal
 from fractions import Fraction
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import IO, Any, AnyStr, Dict, List, Literal, Optional, Union
 from warnings import warn
 from zipfile import ZIP_DEFLATED, LargeZipFile, ZipFile, ZipInfo
 
@@ -62,7 +62,9 @@ class Workbook(xmlwriter.XMLwriter):
     worksheet_class = Worksheet
 
     def __init__(
-        self, filename: Optional[str] = None, options: Optional[Dict[str, Any]] = None
+        self,
+        filename: Optional[str | IO[AnyStr] | os.PathLike] = None,
+        options: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Constructor.


### PR DESCRIPTION
This PR adds more supported types to filename in `Workbook` class to match supported `zipfile` file types.

According to [zipfile docs](https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile)

> file can be a path to a file (a string), a file-like object or a [path-like object](https://docs.python.org/3/glossary.html#term-path-like-object).

I added `IO[AnyStr]` for `file-like object` and `os.PathLike` for `path-like object`

Closes #1152