### PR TITLE
export Workbook

### DIFF
--- a/xlsxwriter/__init__.py
+++ b/xlsxwriter/__init__.py
@@ -6,3 +6,5 @@
 __version__ = "3.2.7"
 __VERSION__ = __version__
 from .workbook import Workbook  # noqa
+
+__all__ = ["Workbook"]


### PR DESCRIPTION
This PR exports Workbook

```console
$ cat t.py
from xlsxwriter import Workbook
```

Steps:
install mypy and xlsxwriter

```bash
pip install mypy .
```

Check error on main branch

```
❯ mypy --follow-imports=silent --strict t.py
t.py:1: error: Module "xlsxwriter" does not explicitly export attribute "Workbook"  [attr-defined]
Found 1 error in 1 file (checked 1 source file)
```

After patch (checkout PR):

```
❯ mypy --follow-imports=silent --strict t.py
Success: no issues found in 1 source file
```

Closes #1154 