### PR TITLE
worksheet: add overload signatures for cell, range and column methods

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install test dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest flake8 black ruff isort pylint polars pandas
+        pip install pytest flake8 black ruff isort pylint polars pandas typing-extensions
 
     - name: Test the code style
       run: |

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ testpythons:
 	@~/.pythonbrew/pythons/Python-3.13.0/bin/py.test -q
 
 test_flake8:
-	@ls -1 xlsxwriter/*.py | egrep -v "theme|__init__" | xargs flake8 --show-source --max-line-length=88 --ignore=E203,W503
+	@ls -1 xlsxwriter/*.py | egrep -v "theme|__init__" | xargs flake8 --show-source --max-line-length=88 --ignore=E203,E704,W503
 	@flake8 --ignore=E501 xlsxwriter/theme.py
 	@find xlsxwriter/test -name \*.py | xargs flake8 --ignore=E501,F841,W503
 


### PR DESCRIPTION
Completes the typing signature of the decorators in `worksheet.py`.

Fixes #1157. No runtime changes were made.
