### PR TITLE
Fix off-by-one error in "Pandas Excel output with user defined header format" example

### DIFF
--- a/examples/pandas_header_format.py
+++ b/examples/pandas_header_format.py
@@ -38,8 +38,8 @@ header_format = workbook.add_format(
 )
 
 # Write the column headers with the defined format.
-for col_num, value in enumerate(df.columns.values):
-    worksheet.write(0, col_num + 1, value, header_format)
+for col_num, value in enumerate(df.columns):
+    worksheet.write(0, col_num, value, header_format)
 
 # Close the Pandas Excel writer and output the Excel file.
 writer.close()


### PR DESCRIPTION
[`worksheet.write()` is zero indexed.](https://xlsxwriter.readthedocs.io/worksheet.html#worksheet-write)