### PR TITLE
Fix write() to fall through to str() when float() raises TypeError

### DIFF
--- a/xlsxwriter/test/worksheet/test_write_unknown_types.py
+++ b/xlsxwriter/test/worksheet/test_write_unknown_types.py
@@ -1,0 +1,134 @@
+###############################################################################
+#
+# Tests for XlsxWriter.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c), 2013-2025, John McNamara, jmcnamara@cpan.org
+#
+
+import os
+import tempfile
+import unittest
+from dataclasses import dataclass
+
+from xlsxwriter.workbook import Workbook
+
+
+class TestWriteUnknownTypes(unittest.TestCase):
+    """
+    Test write() handling of types that are not natively supported.
+
+    When float() raises TypeError for an unsupported type, write() should fall
+    through to the str() fallback rather than immediately re-raising. Both
+    paths are tested here.
+    """
+
+    def _make_workbook(self, tmp_path):
+        """Create a Workbook backed by a temp file."""
+        return Workbook(tmp_path)
+
+    def test_write_dataclass_falls_back_to_str(self):
+        """write() should use str() for a dataclass instead of raising TypeError."""
+
+        @dataclass
+        class Point:
+            x: int
+            y: int
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as f:
+            tmp = f.name
+        try:
+            workbook = Workbook(tmp)
+            worksheet = workbook.add_worksheet()
+            # Should NOT raise; should write str(Point(1, 2)) as a string cell.
+            worksheet.write(0, 0, Point(1, 2))
+            workbook.close()
+        finally:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+
+    def test_write_custom_object_falls_back_to_str(self):
+        """write() should use str() for objects that do not support float()."""
+
+        class MyObj:
+            def __str__(self):
+                return "custom_value"
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as f:
+            tmp = f.name
+        try:
+            workbook = Workbook(tmp)
+            worksheet = workbook.add_worksheet()
+            worksheet.write(0, 0, MyObj())
+            workbook.close()
+        finally:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+
+    def test_write_object_with_float_value_error_falls_back_to_str(self):
+        """write() str() fallback is used when __float__ raises ValueError."""
+
+        class WeirdFloat:
+            def __float__(self):
+                raise ValueError("not a number")
+
+            def __str__(self):
+                return "weird_object"
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as f:
+            tmp = f.name
+        try:
+            workbook = Workbook(tmp)
+            worksheet = workbook.add_worksheet()
+            worksheet.write(0, 0, WeirdFloat())
+            workbook.close()
+        finally:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+
+    def test_write_truly_unsupported_type_raises_type_error(self):
+        """write() should raise TypeError when neither float() nor str() works."""
+
+        class Unsupported:
+            def __float__(self):
+                raise TypeError("no float")
+
+            def __str__(self):
+                raise TypeError("no str")
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as f:
+            tmp = f.name
+        try:
+            workbook = Workbook(tmp)
+            worksheet = workbook.add_worksheet()
+            with self.assertRaises(TypeError):
+                worksheet.write(0, 0, Unsupported())
+            workbook.close()
+        finally:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+
+    def test_write_row_with_mixed_types_including_dataclass(self):
+        """write_row() should handle a row mixing standard types and a dataclass."""
+
+        @dataclass
+        class Payload:
+            value: str
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as f:
+            tmp = f.name
+        try:
+            workbook = Workbook(tmp)
+            worksheet = workbook.add_worksheet()
+            worksheet.write_row(
+                0, 0, [1, True, 1.0, "hello", Payload(value="world")]
+            )
+            workbook.close()
+        finally:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -651,16 +651,14 @@ class Worksheet(xmlwriter.XMLwriter):
         try:
             f = float(token)
             return self._write_number(row, col, f, *args[1:])
-        except ValueError:
+        except (ValueError, TypeError):
             pass
-        except TypeError:
-            raise TypeError(f"Unsupported type {type(token)} in write()")
 
         # Finally try string.
         try:
-            str(token)
-            return self._write_string(row, col, *args)
-        except ValueError:
+            s = str(token)
+            return self._write_string(row, col, s, *args[1:])
+        except (ValueError, TypeError):
             raise TypeError(f"Unsupported type {type(token)} in write()")
 
     @convert_cell_args


### PR DESCRIPTION
## Summary

Fixes #1190.

`_write()` has a float-then-string fallback path for types that are not
natively recognised. However, if `float(token)` raises `TypeError` (which
happens for any object that does not implement `__float__`, such as a
dataclass), the code immediately re-raises instead of trying the `str()`
fallback. As a result, even objects for which `str()` works perfectly produce
an unhelpful `"Unsupported type ... in write()"` error.

There is a related second issue in the `str()` path itself: it called
`str(token)` only to test whether the conversion succeeds, then passed the
original unconverted `token` to `_write_string()`, which immediately fails on
`len(token)` for objects that do not implement `__len__`.

### Changes

**`xlsxwriter/worksheet.py`** (`_write()`):

- Catch `TypeError` from `float()` the same way as `ValueError` (`pass`
  instead of `raise`) so execution reaches the `str()` fallback.
- Store the result of `str(token)` in a local variable and pass it explicitly
  to `_write_string()`, replacing the raw token in `args`.
- Also catch `TypeError` (in addition to `ValueError`) in the `str()` fallback
  for robustness.

**`xlsxwriter/test/worksheet/test_write_unknown_types.py`** (new):

Five unit tests covering:
1. Dataclass written via `str()` fallback.
2. Custom object without `__float__` written via `str()` fallback.
3. Object whose `__float__` raises `ValueError` written via `str()` fallback.
4. Object where both conversions raise `TypeError` still raises `TypeError`.
5. `write_row()` with a row mixing standard types and a dataclass.

### Before / After

```python
# Before
worksheet.write_row(0, 0, [1, True, 1.0, "hello", MyDataclass(...)])
# TypeError: Unsupported type <class 'MyDataclass'> in write()

# After
worksheet.write_row(0, 0, [1, True, 1.0, "hello", MyDataclass(...)])
# Writes str(MyDataclass(...)) into the cell — no error.
```

---

This pull request was prepared with the assistance of AI, under my direction and review.