### PR TITLE
fix: guard short paths in Url._is_relative_path

### DIFF
--- a/xlsxwriter/test/worksheet/test_write_url_short_path.py
+++ b/xlsxwriter/test/worksheet/test_write_url_short_path.py
@@ -1,0 +1,42 @@
+###############################################################################
+#
+# Tests for XlsxWriter.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c), 2013-2025, John McNamara, jmcnamara@cpan.org
+#
+
+import unittest
+from io import BytesIO
+
+from xlsxwriter.url import Url
+from xlsxwriter.workbook import Workbook
+
+
+class TestWriteUrlShortPath(unittest.TestCase):
+    """Short file/external paths must not IndexError in _is_relative_path."""
+
+    def test_is_relative_path_short_strings(self):
+        self.assertTrue(Url._is_relative_path(""))
+        self.assertTrue(Url._is_relative_path("a"))
+        self.assertTrue(Url._is_relative_path("ab"))
+        self.assertFalse(Url._is_relative_path("C:"))
+        self.assertFalse(Url._is_relative_path("C:\\foo"))
+        self.assertFalse(Url._is_relative_path(r"\\server\share"))
+
+    def test_write_url_file_short_path(self):
+        workbook = Workbook(BytesIO(), {"in_memory": True})
+        workbook.default_url_format = None
+        worksheet = workbook.add_worksheet()
+        worksheet.write_url("A1", "file:///a")
+        workbook.close()
+        self.assertEqual(worksheet.hyperlinks[0][0]._link, "a")
+
+    def test_write_url_external_short_path(self):
+        workbook = Workbook(BytesIO(), {"in_memory": True})
+        workbook.default_url_format = None
+        worksheet = workbook.add_worksheet()
+        worksheet.write_url("A1", "external:a")
+        workbook.close()
+        self.assertEqual(worksheet.hyperlinks[0][0]._link, "a")

--- a/xlsxwriter/url.py
+++ b/xlsxwriter/url.py
@@ -240,7 +240,8 @@ class Url:
         if url.startswith(r"\\"):
             return False
 
-        if url[0].isalpha() and url[1] == ":":
+        # Drive paths need two chars (e.g. "C:"); shorter paths are relative.
+        if len(url) >= 2 and url[0].isalpha() and url[1] == ":":
             return False
 
         return True


### PR DESCRIPTION
Fixes #1196.

`worksheet.write_url("A1", "file:///a")` (and short `external:` paths) raise `IndexError` in `Url._is_relative_path` when the path has fewer than two characters. Guard that case and add a regression test.