### PR TITLE
fix: accept single-letter columns in set_column A1 form

### DIFF
--- a/xlsxwriter/test/worksheet/test_set_column_single_letter.py
+++ b/xlsxwriter/test/worksheet/test_set_column_single_letter.py
@@ -31,3 +31,19 @@ class TestSetColumnSingleLetter(unittest.TestCase):
         worksheet = workbook.add_worksheet()
         self.assertEqual(worksheet.set_column("B:D", 5), 0)
         workbook.close()
+
+    def test_set_column_empty_raises_clear_error(self):
+        workbook = Workbook(BytesIO(), {"in_memory": True})
+        worksheet = workbook.add_worksheet()
+        with self.assertRaises(ValueError) as ctx:
+            worksheet.set_column("", 10)
+        self.assertIn("Unknown column range", str(ctx.exception))
+        workbook.close()
+
+    def test_set_column_multi_colon_raises_clear_error(self):
+        workbook = Workbook(BytesIO(), {"in_memory": True})
+        worksheet = workbook.add_worksheet()
+        with self.assertRaises(ValueError) as ctx:
+            worksheet.set_column("::", 10)
+        self.assertIn("Unknown column range", str(ctx.exception))
+        workbook.close()

--- a/xlsxwriter/test/worksheet/test_set_column_single_letter.py
+++ b/xlsxwriter/test/worksheet/test_set_column_single_letter.py
@@ -1,0 +1,49 @@
+###############################################################################
+#
+# Tests for XlsxWriter.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c), 2013-2025, John McNamara, jmcnamara@cpan.org
+#
+
+import unittest
+from io import BytesIO
+
+from xlsxwriter.workbook import Workbook
+
+
+class TestSetColumnSingleLetter(unittest.TestCase):
+    """Single-column A1 letters must work as A:A, not ValueError unpack."""
+
+    def test_set_column_single_letter(self):
+        workbook = Workbook(BytesIO(), {"in_memory": True})
+        worksheet = workbook.add_worksheet()
+        self.assertEqual(worksheet.set_column("A", 10), 0)
+        self.assertEqual(worksheet.set_column("AA", 12), 0)
+        # Same pixel width as set_column("A:A", 10) / ("AA:AA", 12).
+        self.assertEqual(worksheet.col_info[0].width, 75)
+        self.assertEqual(worksheet.col_info[26].width, 89)
+        workbook.close()
+
+    def test_set_column_a1_range_still_ok(self):
+        workbook = Workbook(BytesIO(), {"in_memory": True})
+        worksheet = workbook.add_worksheet()
+        self.assertEqual(worksheet.set_column("B:D", 5), 0)
+        workbook.close()
+
+    def test_set_column_empty_raises_clear_error(self):
+        workbook = Workbook(BytesIO(), {"in_memory": True})
+        worksheet = workbook.add_worksheet()
+        with self.assertRaises(ValueError) as ctx:
+            worksheet.set_column("", 10)
+        self.assertIn("Unknown column range", str(ctx.exception))
+        workbook.close()
+
+    def test_set_column_multi_colon_raises_clear_error(self):
+        workbook = Workbook(BytesIO(), {"in_memory": True})
+        worksheet = workbook.add_worksheet()
+        with self.assertRaises(ValueError) as ctx:
+            worksheet.set_column("::", 10)
+        self.assertIn("Unknown column range", str(ctx.exception))
+        workbook.close()

--- a/xlsxwriter/test/worksheet/test_set_column_single_letter.py
+++ b/xlsxwriter/test/worksheet/test_set_column_single_letter.py
@@ -31,19 +31,3 @@ class TestSetColumnSingleLetter(unittest.TestCase):
         worksheet = workbook.add_worksheet()
         self.assertEqual(worksheet.set_column("B:D", 5), 0)
         workbook.close()
-
-    def test_set_column_empty_raises_clear_error(self):
-        workbook = Workbook(BytesIO(), {"in_memory": True})
-        worksheet = workbook.add_worksheet()
-        with self.assertRaises(ValueError) as ctx:
-            worksheet.set_column("", 10)
-        self.assertIn("Unknown column range", str(ctx.exception))
-        workbook.close()
-
-    def test_set_column_multi_colon_raises_clear_error(self):
-        workbook = Workbook(BytesIO(), {"in_memory": True})
-        worksheet = workbook.add_worksheet()
-        with self.assertRaises(ValueError) as ctx:
-            worksheet.set_column("::", 10)
-        self.assertIn("Unknown column range", str(ctx.exception))
-        workbook.close()

--- a/xlsxwriter/test/worksheet/test_set_column_single_letter.py
+++ b/xlsxwriter/test/worksheet/test_set_column_single_letter.py
@@ -32,18 +32,4 @@ class TestSetColumnSingleLetter(unittest.TestCase):
         self.assertEqual(worksheet.set_column("B:D", 5), 0)
         workbook.close()
 
-    def test_set_column_empty_raises_clear_error(self):
-        workbook = Workbook(BytesIO(), {"in_memory": True})
-        worksheet = workbook.add_worksheet()
-        with self.assertRaises(ValueError) as ctx:
-            worksheet.set_column("", 10)
-        self.assertIn("Unknown column range", str(ctx.exception))
-        workbook.close()
 
-    def test_set_column_multi_colon_raises_clear_error(self):
-        workbook = Workbook(BytesIO(), {"in_memory": True})
-        worksheet = workbook.add_worksheet()
-        with self.assertRaises(ValueError) as ctx:
-            worksheet.set_column("::", 10)
-        self.assertIn("Unknown column range", str(ctx.exception))
-        workbook.close()

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -232,7 +232,15 @@ def convert_column_args(
                 int(args[0])
         except ValueError:
             # First arg isn't an int, convert to A1 notation.
-            cell_1, cell_2 = [col + "1" for col in args[0].split(":")]
+            # Allow "A" as "A:A"; reject empty or multi-colon ranges.
+            parts = args[0].split(":")
+            if len(parts) == 1:
+                if parts[0] == "":
+                    raise ValueError(f"Unknown column range: {args[0]}")
+                parts = [parts[0], parts[0]]
+            elif len(parts) != 2:
+                raise ValueError(f"Unknown column range: {args[0]}")
+            cell_1, cell_2 = [col + "1" for col in parts]
             _, col_1 = xl_cell_to_rowcol(cell_1)
             _, col_2 = xl_cell_to_rowcol(cell_2)
             new_args = [col_1, col_2]

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -232,17 +232,14 @@ def convert_column_args(
                 int(args[0])
         except ValueError:
             # First arg isn't an int, convert to A1 notation.
-            # Allow "A" as "A:A"; reject empty or multi-colon ranges.
-            parts = args[0].split(":")
-            if len(parts) == 1:
-                if parts[0] == "":
-                    raise ValueError(f"Unknown column range: {args[0]}")
-                parts = [parts[0], parts[0]]
-            elif len(parts) != 2:
-                raise ValueError(f"Unknown column range: {args[0]}")
-            cell_1, cell_2 = [col + "1" for col in parts]
-            _, col_1 = xl_cell_to_rowcol(cell_1)
-            _, col_2 = xl_cell_to_rowcol(cell_2)
+            # Single column letter ("A") matches convert_range_args: treat as A:A.
+            if ":" in args[0]:
+                cell_1, cell_2 = [col + "1" for col in args[0].split(":")]
+                _, col_1 = xl_cell_to_rowcol(cell_1)
+                _, col_2 = xl_cell_to_rowcol(cell_2)
+            else:
+                _, col_1 = xl_cell_to_rowcol(args[0] + "1")
+                col_2 = col_1
             new_args = [col_1, col_2]
             new_args.extend(args[1:])
             args = new_args

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -232,14 +232,17 @@ def convert_column_args(
                 int(args[0])
         except ValueError:
             # First arg isn't an int, convert to A1 notation.
-            # Single column letter ("A") matches convert_range_args: treat as A:A.
-            if ":" in args[0]:
-                cell_1, cell_2 = [col + "1" for col in args[0].split(":")]
-                _, col_1 = xl_cell_to_rowcol(cell_1)
-                _, col_2 = xl_cell_to_rowcol(cell_2)
-            else:
-                _, col_1 = xl_cell_to_rowcol(args[0] + "1")
-                col_2 = col_1
+            # Allow "A" as "A:A"; reject empty or multi-colon ranges.
+            parts = args[0].split(":")
+            if len(parts) == 1:
+                if parts[0] == "":
+                    raise ValueError(f"Unknown column range: {args[0]}")
+                parts = [parts[0], parts[0]]
+            elif len(parts) != 2:
+                raise ValueError(f"Unknown column range: {args[0]}")
+            cell_1, cell_2 = [col + "1" for col in parts]
+            _, col_1 = xl_cell_to_rowcol(cell_1)
+            _, col_2 = xl_cell_to_rowcol(cell_2)
             new_args = [col_1, col_2]
             new_args.extend(args[1:])
             args = new_args


### PR DESCRIPTION
Fixes #1197.

`worksheet.set_column("A", 10)` raises `ValueError` because a single column letter is not accepted as `A:A`. Treat bare column letters like `A:A` / `AA:AA` and add a regression test.